### PR TITLE
Get hpricot to run on Rubinius

### DIFF
--- a/ext/hpricot_scan/hpricot_scan.c
+++ b/ext/hpricot_scan/hpricot_scan.c
@@ -9,6 +9,12 @@
  * Copyright (C) 2006 why the lucky stiff
  */
 #include <ruby.h>
+#include <assert.h>
+
+struct hpricot_struct {
+  int len;
+  VALUE* ptr;
+};
 
 #ifndef RARRAY_LEN
 #define RARRAY_LEN(arr)  RARRAY(arr)->len
@@ -39,8 +45,10 @@ static VALUE reProcInsParse;
 #define H_ELE_HASH     6
 #define H_ELE_CHILDREN 7
 
-#define H_ELE_GET(ele, idx)      RSTRUCT_PTR(ele)[idx]
-#define H_ELE_SET(ele, idx, val) RSTRUCT_PTR(ele)[idx] = val
+#define HSTRUCT_PTR(ele) ((struct hpricot_struct*)DATA_PTR(ele))->ptr
+
+#define H_ELE_GET(ele, idx)      HSTRUCT_PTR(ele)[idx]
+#define H_ELE_SET(ele, idx, val) HSTRUCT_PTR(ele)[idx] = val
 
 #define OPT(opts, key) (!NIL_P(opts) && RTEST(rb_hash_aref(opts, ID2SYM(rb_intern("" # key)))))
 
@@ -95,11 +103,11 @@ static VALUE reProcInsParse;
 #define EBLK(N, T) CAT(tag, p - T + 1); ELE(N);
 
 
-#line 142 "hpricot_scan.rl"
+#line 150 "hpricot_scan.rl"
 
 
 
-#line 103 "hpricot_scan.c"
+#line 111 "hpricot_scan.c"
 static const int hpricot_scan_start = 204;
 static const int hpricot_scan_error = -1;
 
@@ -109,7 +117,7 @@ static const int hpricot_scan_en_html_procins = 218;
 static const int hpricot_scan_en_main = 204;
 
 
-#line 145 "hpricot_scan.rl"
+#line 153 "hpricot_scan.rl"
 
 #define BUFSIZE 16384
 
@@ -377,7 +385,7 @@ rb_hpricot_token(hpricot_state *S, VALUE sym, VALUE tag, VALUE attr, char *raw, 
     }
   } else if (sym == sym_text) {
     // TODO: add raw_string as well?
-    if (!NIL_P(S->last) && RBASIC(S->last)->klass == cText) {
+    if (!NIL_P(S->last) && RTEST(rb_obj_is_instance_of(S->last, cText))) {
       rb_str_append(H_ELE_GET(S->last, H_ELE_TAG), tag);
     } else {
       H_ELE(cText);
@@ -447,7 +455,7 @@ VALUE hpricot_scan(int argc, VALUE *argv, VALUE self)
     buf = ALLOC_N(char, buffer_size);
 
   
-#line 451 "hpricot_scan.c"
+#line 459 "hpricot_scan.c"
 	{
 	cs = hpricot_scan_start;
 	ts = 0;
@@ -455,7 +463,7 @@ VALUE hpricot_scan(int argc, VALUE *argv, VALUE self)
 	act = 0;
 	}
 
-#line 482 "hpricot_scan.rl"
+#line 490 "hpricot_scan.rl"
 
   while (!done) {
     VALUE str;
@@ -508,7 +516,7 @@ VALUE hpricot_scan(int argc, VALUE *argv, VALUE self)
 
     pe = p + len;
     
-#line 512 "hpricot_scan.c"
+#line 520 "hpricot_scan.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -523,7 +531,7 @@ tr4:
 	{te = p+1;{ {goto st214;} }}
 	goto st204;
 tr15:
-#line 113 "hpricot_scan.rl"
+#line 121 "hpricot_scan.rl"
 	{ SET(tag, p); }
 #line 66 "hpricot_common.rl"
 	{te = p+1;{ ELE(doctype); }}
@@ -555,7 +563,7 @@ tr93:
 	{te = p+1;{ {goto st216;} }}
 	goto st204;
 tr97:
-#line 113 "hpricot_scan.rl"
+#line 121 "hpricot_scan.rl"
 	{ SET(tag, p); }
 #line 69 "hpricot_common.rl"
 	{te = p+1;{ ELE(etag); }}
@@ -565,7 +573,7 @@ tr99:
 	{te = p+1;{ ELE(etag); }}
 	goto st204;
 tr103:
-#line 113 "hpricot_scan.rl"
+#line 121 "hpricot_scan.rl"
 	{ SET(tag, p); }
 #line 68 "hpricot_common.rl"
 	{te = p+1;{ ELE(stag); }}
@@ -575,9 +583,9 @@ tr107:
 	{te = p+1;{ ELE(stag); }}
 	goto st204;
 tr112:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -587,7 +595,7 @@ tr112:
 	{te = p+1;{ ELE(stag); }}
 	goto st204;
 tr117:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -601,12 +609,12 @@ tr118:
 	{te = p+1;{ ELE(emptytag); }}
 	goto st204;
 tr129:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -616,13 +624,13 @@ tr129:
 	{te = p+1;{ ELE(stag); }}
 	goto st204;
 tr133:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -631,14 +639,14 @@ tr133:
 	{te = p+1;{ ELE(stag); }}
 	goto st204;
 tr139:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -685,7 +693,7 @@ st204:
 case 204:
 #line 1 "NONE"
 	{ts = p;}
-#line 689 "hpricot_scan.c"
+#line 697 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 10: goto tr412;
 		case 60: goto tr413;
@@ -694,7 +702,7 @@ case 204:
 tr413:
 #line 1 "NONE"
 	{te = p+1;}
-#line 98 "hpricot_scan.rl"
+#line 106 "hpricot_scan.rl"
 	{
     if (text == 1) {
       CAT(tag, p);
@@ -713,7 +721,7 @@ st205:
 	if ( ++p == pe )
 		goto _test_eof205;
 case 205:
-#line 717 "hpricot_scan.c"
+#line 725 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 33: goto st0;
 		case 47: goto st59;
@@ -814,14 +822,14 @@ case 9:
 		goto tr12;
 	goto tr0;
 tr12:
-#line 110 "hpricot_scan.rl"
+#line 118 "hpricot_scan.rl"
 	{ mark_tag = p; }
 	goto st10;
 st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 825 "hpricot_scan.c"
+#line 833 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto tr13;
 		case 62: goto tr15;
@@ -845,14 +853,14 @@ case 10:
 		goto st10;
 	goto tr0;
 tr13:
-#line 113 "hpricot_scan.rl"
+#line 121 "hpricot_scan.rl"
 	{ SET(tag, p); }
 	goto st11;
 st11:
 	if ( ++p == pe )
 		goto _test_eof11;
 case 11:
-#line 856 "hpricot_scan.c"
+#line 864 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st11;
 		case 62: goto tr18;
@@ -942,14 +950,14 @@ case 19:
 		goto tr30;
 	goto tr0;
 tr30:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st20;
 st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 953 "hpricot_scan.c"
+#line 961 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 9: goto st20;
 		case 34: goto tr33;
@@ -969,20 +977,20 @@ case 20:
 		goto st20;
 	goto tr0;
 tr31:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 124 "hpricot_scan.rl"
+#line 132 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("public_id")), aval); }
 	goto st21;
 tr33:
-#line 124 "hpricot_scan.rl"
+#line 132 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("public_id")), aval); }
 	goto st21;
 st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 986 "hpricot_scan.c"
+#line 994 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st22;
 		case 62: goto tr18;
@@ -1013,32 +1021,32 @@ case 23:
 		goto tr38;
 	goto tr37;
 tr37:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st24;
 st24:
 	if ( ++p == pe )
 		goto _test_eof24;
 case 24:
-#line 1024 "hpricot_scan.c"
+#line 1032 "hpricot_scan.c"
 	if ( (*p) == 34 )
 		goto tr41;
 	goto st24;
 tr38:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 125 "hpricot_scan.rl"
+#line 133 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("system_id")), aval); }
 	goto st25;
 tr41:
-#line 125 "hpricot_scan.rl"
+#line 133 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("system_id")), aval); }
 	goto st25;
 st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 1042 "hpricot_scan.c"
+#line 1050 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st25;
 		case 62: goto tr18;
@@ -1048,14 +1056,14 @@ case 25:
 		goto st25;
 	goto tr39;
 tr16:
-#line 113 "hpricot_scan.rl"
+#line 121 "hpricot_scan.rl"
 	{ SET(tag, p); }
 	goto st26;
 st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 1059 "hpricot_scan.c"
+#line 1067 "hpricot_scan.c"
 	if ( (*p) == 93 )
 		goto st27;
 	goto st26;
@@ -1078,14 +1086,14 @@ case 28:
 		goto tr38;
 	goto tr44;
 tr44:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st29;
 st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 1089 "hpricot_scan.c"
+#line 1097 "hpricot_scan.c"
 	if ( (*p) == 39 )
 		goto tr41;
 	goto st29;
@@ -1115,14 +1123,14 @@ case 30:
 		goto tr46;
 	goto tr0;
 tr46:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st31;
 st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 1126 "hpricot_scan.c"
+#line 1134 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 9: goto st31;
 		case 39: goto tr49;
@@ -1145,34 +1153,34 @@ case 31:
 		goto st31;
 	goto tr0;
 tr47:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 124 "hpricot_scan.rl"
+#line 132 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("public_id")), aval); }
 	goto st32;
 tr49:
-#line 124 "hpricot_scan.rl"
+#line 132 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("public_id")), aval); }
 	goto st32;
 tr55:
-#line 124 "hpricot_scan.rl"
+#line 132 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("public_id")), aval); }
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 125 "hpricot_scan.rl"
+#line 133 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("system_id")), aval); }
 	goto st32;
 tr82:
-#line 124 "hpricot_scan.rl"
+#line 132 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("public_id")), aval); }
-#line 125 "hpricot_scan.rl"
+#line 133 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("system_id")), aval); }
 	goto st32;
 st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 1176 "hpricot_scan.c"
+#line 1184 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 9: goto st33;
 		case 32: goto st33;
@@ -1226,20 +1234,20 @@ case 33:
 		goto st31;
 	goto tr0;
 tr51:
-#line 124 "hpricot_scan.rl"
+#line 132 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("public_id")), aval); }
 	goto st34;
 tr62:
-#line 124 "hpricot_scan.rl"
+#line 132 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("public_id")), aval); }
-#line 125 "hpricot_scan.rl"
+#line 133 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("system_id")), aval); }
 	goto st34;
 st34:
 	if ( ++p == pe )
 		goto _test_eof34;
 case 34:
-#line 1243 "hpricot_scan.c"
+#line 1251 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 9: goto tr52;
 		case 32: goto tr52;
@@ -1265,14 +1273,14 @@ case 34:
 		goto tr54;
 	goto tr44;
 tr52:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st35;
 st35:
 	if ( ++p == pe )
 		goto _test_eof35;
 case 35:
-#line 1276 "hpricot_scan.c"
+#line 1284 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 9: goto st35;
 		case 32: goto st35;
@@ -1298,14 +1306,14 @@ case 35:
 		goto st47;
 	goto st29;
 tr53:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st36;
 st36:
 	if ( ++p == pe )
 		goto _test_eof36;
 case 36:
-#line 1309 "hpricot_scan.c"
+#line 1317 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st36;
 		case 34: goto st37;
@@ -1326,38 +1334,38 @@ case 37:
 	}
 	goto tr66;
 tr66:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st38;
 st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
-#line 1337 "hpricot_scan.c"
+#line 1345 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 34: goto tr70;
 		case 39: goto tr71;
 	}
 	goto st38;
 tr81:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st39;
 tr67:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 125 "hpricot_scan.rl"
+#line 133 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("system_id")), aval); }
 	goto st39;
 tr70:
-#line 125 "hpricot_scan.rl"
+#line 133 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("system_id")), aval); }
 	goto st39;
 st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
-#line 1361 "hpricot_scan.c"
+#line 1369 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st39;
 		case 39: goto tr41;
@@ -1370,7 +1378,7 @@ case 39:
 tr56:
 #line 1 "NONE"
 	{te = p+1;}
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 #line 66 "hpricot_common.rl"
 	{act = 8;}
@@ -1385,33 +1393,33 @@ st206:
 	if ( ++p == pe )
 		goto _test_eof206;
 case 206:
-#line 1389 "hpricot_scan.c"
+#line 1397 "hpricot_scan.c"
 	if ( (*p) == 39 )
 		goto tr41;
 	goto st29;
 tr57:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st40;
 st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-#line 1401 "hpricot_scan.c"
+#line 1409 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 39: goto tr73;
 		case 93: goto st42;
 	}
 	goto st40;
 tr73:
-#line 125 "hpricot_scan.rl"
+#line 133 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("system_id")), aval); }
 	goto st41;
 st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
-#line 1415 "hpricot_scan.c"
+#line 1423 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st41;
 		case 62: goto tr76;
@@ -1430,7 +1438,7 @@ st207:
 	if ( ++p == pe )
 		goto _test_eof207;
 case 207:
-#line 1434 "hpricot_scan.c"
+#line 1442 "hpricot_scan.c"
 	if ( (*p) == 93 )
 		goto st27;
 	goto st26;
@@ -1447,20 +1455,20 @@ case 42:
 		goto st42;
 	goto st29;
 tr68:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 125 "hpricot_scan.rl"
+#line 133 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("system_id")), aval); }
 	goto st43;
 tr71:
-#line 125 "hpricot_scan.rl"
+#line 133 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("system_id")), aval); }
 	goto st43;
 st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 1464 "hpricot_scan.c"
+#line 1472 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st43;
 		case 34: goto tr41;
@@ -1480,7 +1488,7 @@ st208:
 	if ( ++p == pe )
 		goto _test_eof208;
 case 208:
-#line 1484 "hpricot_scan.c"
+#line 1492 "hpricot_scan.c"
 	if ( (*p) == 34 )
 		goto tr41;
 	goto st24;
@@ -1506,14 +1514,14 @@ case 45:
 		goto st45;
 	goto st24;
 tr65:
-#line 125 "hpricot_scan.rl"
+#line 133 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("system_id")), aval); }
 	goto st46;
 st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 1517 "hpricot_scan.c"
+#line 1525 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto tr81;
 		case 39: goto tr38;
@@ -1524,14 +1532,14 @@ case 46:
 		goto tr81;
 	goto tr44;
 tr54:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st47;
 st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
-#line 1535 "hpricot_scan.c"
+#line 1543 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 9: goto st47;
 		case 39: goto tr82;
@@ -1645,14 +1653,14 @@ case 59:
 		goto tr94;
 	goto tr0;
 tr94:
-#line 110 "hpricot_scan.rl"
+#line 118 "hpricot_scan.rl"
 	{ mark_tag = p; }
 	goto st60;
 st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-#line 1656 "hpricot_scan.c"
+#line 1664 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto tr95;
 		case 62: goto tr97;
@@ -1675,14 +1683,14 @@ case 60:
 		goto st60;
 	goto tr0;
 tr95:
-#line 113 "hpricot_scan.rl"
+#line 121 "hpricot_scan.rl"
 	{ SET(tag, p); }
 	goto st61;
 st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
-#line 1686 "hpricot_scan.c"
+#line 1694 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st61;
 		case 62: goto tr99;
@@ -1691,14 +1699,14 @@ case 61:
 		goto st61;
 	goto tr0;
 tr417:
-#line 110 "hpricot_scan.rl"
+#line 118 "hpricot_scan.rl"
 	{ mark_tag = p; }
 	goto st62;
 st62:
 	if ( ++p == pe )
 		goto _test_eof62;
 case 62:
-#line 1702 "hpricot_scan.c"
+#line 1710 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto tr100;
 		case 47: goto tr102;
@@ -1719,14 +1727,14 @@ case 62:
 		goto st62;
 	goto tr0;
 tr100:
-#line 113 "hpricot_scan.rl"
+#line 121 "hpricot_scan.rl"
 	{ SET(tag, p); }
 	goto st63;
 st63:
 	if ( ++p == pe )
 		goto _test_eof63;
 case 63:
-#line 1730 "hpricot_scan.c"
+#line 1738 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st63;
 		case 47: goto st66;
@@ -1747,38 +1755,38 @@ case 63:
 		goto tr105;
 	goto tr0;
 tr105:
-#line 127 "hpricot_scan.rl"
+#line 135 "hpricot_scan.rl"
 	{
     akey = Qnil;
     aval = Qnil;
     mark_akey = NULL;
     mark_aval = NULL;
   }
-#line 112 "hpricot_scan.rl"
+#line 120 "hpricot_scan.rl"
 	{ mark_akey = p; }
 	goto st64;
 tr114:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 127 "hpricot_scan.rl"
+#line 135 "hpricot_scan.rl"
 	{
     akey = Qnil;
     aval = Qnil;
     mark_akey = NULL;
     mark_aval = NULL;
   }
-#line 112 "hpricot_scan.rl"
+#line 120 "hpricot_scan.rl"
 	{ mark_akey = p; }
 	goto st64;
 st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-#line 1782 "hpricot_scan.c"
+#line 1790 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto tr108;
 		case 47: goto tr110;
@@ -1800,20 +1808,20 @@ case 64:
 		goto st64;
 	goto tr39;
 tr108:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
 	goto st65;
 tr140:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st65;
 tr134:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -1823,7 +1831,7 @@ st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
-#line 1827 "hpricot_scan.c"
+#line 1835 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st65;
 		case 47: goto tr115;
@@ -1845,13 +1853,13 @@ case 65:
 		goto tr114;
 	goto tr39;
 tr102:
-#line 113 "hpricot_scan.rl"
+#line 121 "hpricot_scan.rl"
 	{ SET(tag, p); }
 	goto st66;
 tr110:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -1859,7 +1867,7 @@ tr110:
   }
 	goto st66;
 tr115:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -1870,19 +1878,19 @@ st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-#line 1874 "hpricot_scan.c"
+#line 1882 "hpricot_scan.c"
 	if ( (*p) == 62 )
 		goto tr118;
 	goto tr39;
 tr111:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
 	goto st67;
 st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
-#line 1886 "hpricot_scan.c"
+#line 1894 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr120;
 		case 32: goto tr120;
@@ -1899,14 +1907,14 @@ case 67:
 		goto tr120;
 	goto tr119;
 tr119:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st68;
 st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 1910 "hpricot_scan.c"
+#line 1918 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr126;
 		case 32: goto tr126;
@@ -1921,27 +1929,27 @@ case 68:
 		goto tr126;
 	goto st68;
 tr126:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st69;
 tr331:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st69;
 tr169:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st69;
 st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-#line 1945 "hpricot_scan.c"
+#line 1953 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st69;
 		case 47: goto tr115;
@@ -1962,27 +1970,27 @@ case 69:
 		goto tr114;
 	goto tr39;
 tr127:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st70;
 tr155:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st70;
 tr163:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st70;
 st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
-#line 1986 "hpricot_scan.c"
+#line 1994 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr126;
 		case 32: goto tr126;
@@ -2008,46 +2016,46 @@ case 70:
 		goto tr131;
 	goto st68;
 tr131:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 127 "hpricot_scan.rl"
+#line 135 "hpricot_scan.rl"
 	{
     akey = Qnil;
     aval = Qnil;
     mark_akey = NULL;
     mark_aval = NULL;
   }
-#line 112 "hpricot_scan.rl"
+#line 120 "hpricot_scan.rl"
 	{ mark_akey = p; }
 	goto st71;
 tr150:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 127 "hpricot_scan.rl"
+#line 135 "hpricot_scan.rl"
 	{
     akey = Qnil;
     aval = Qnil;
     mark_akey = NULL;
     mark_aval = NULL;
   }
-#line 112 "hpricot_scan.rl"
+#line 120 "hpricot_scan.rl"
 	{ mark_akey = p; }
 	goto st71;
 st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 2051 "hpricot_scan.c"
+#line 2059 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr134;
 		case 32: goto tr134;
@@ -2074,16 +2082,16 @@ case 71:
 		goto st71;
 	goto st68;
 tr141:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st72;
 tr135:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -2093,7 +2101,7 @@ st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 2097 "hpricot_scan.c"
+#line 2105 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr140;
 		case 32: goto tr140;
@@ -2120,9 +2128,9 @@ case 72:
 		goto tr131;
 	goto st68;
 tr124:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -2130,12 +2138,12 @@ tr124:
   }
 	goto st73;
 tr128:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -2143,27 +2151,27 @@ tr128:
   }
 	goto st73;
 tr132:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st73;
 tr137:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -2171,14 +2179,14 @@ tr137:
   }
 	goto st73;
 tr147:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -2186,15 +2194,15 @@ tr147:
   }
 	goto st73;
 tr151:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -2204,7 +2212,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 2208 "hpricot_scan.c"
+#line 2216 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr126;
 		case 32: goto tr126;
@@ -2219,18 +2227,18 @@ case 73:
 		goto tr126;
 	goto st68;
 tr121:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st74;
 tr138:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
 	goto st74;
 st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 2234 "hpricot_scan.c"
+#line 2242 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr143;
 		case 32: goto tr143;
@@ -2247,13 +2255,13 @@ case 74:
 		goto tr143;
 	goto tr119;
 tr148:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st75;
 tr143:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -2263,7 +2271,7 @@ st75:
 	if ( ++p == pe )
 		goto _test_eof75;
 case 75:
-#line 2267 "hpricot_scan.c"
+#line 2275 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr148;
 		case 32: goto tr148;
@@ -2291,13 +2299,13 @@ case 75:
 		goto tr150;
 	goto tr119;
 tr149:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st76;
 tr144:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -2307,7 +2315,7 @@ st76:
 	if ( ++p == pe )
 		goto _test_eof76;
 case 76:
-#line 2311 "hpricot_scan.c"
+#line 2319 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr143;
 		case 32: goto tr143;
@@ -2354,14 +2362,14 @@ case 77:
 		goto tr153;
 	goto tr152;
 tr152:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st78;
 st78:
 	if ( ++p == pe )
 		goto _test_eof78;
 case 78:
-#line 2365 "hpricot_scan.c"
+#line 2373 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr161;
 		case 32: goto tr161;
@@ -2378,40 +2386,40 @@ case 78:
 		goto tr161;
 	goto st78;
 tr336:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st79;
 tr161:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st79;
 tr153:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st79;
 tr317:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st79;
 tr174:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st79;
 st79:
 	if ( ++p == pe )
 		goto _test_eof79;
 case 79:
-#line 2415 "hpricot_scan.c"
+#line 2423 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st79;
 		case 34: goto tr169;
@@ -2434,74 +2442,74 @@ case 79:
 		goto tr170;
 	goto st80;
 tr157:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st80;
 st80:
 	if ( ++p == pe )
 		goto _test_eof80;
 case 80:
-#line 2445 "hpricot_scan.c"
+#line 2453 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 34: goto tr169;
 		case 92: goto st81;
 	}
 	goto st80;
 tr340:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st81;
 st81:
 	if ( ++p == pe )
 		goto _test_eof81;
 case 81:
-#line 2459 "hpricot_scan.c"
+#line 2467 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 34: goto tr174;
 		case 92: goto st81;
 	}
 	goto st80;
 tr170:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 127 "hpricot_scan.rl"
+#line 135 "hpricot_scan.rl"
 	{
     akey = Qnil;
     aval = Qnil;
     mark_akey = NULL;
     mark_aval = NULL;
   }
-#line 112 "hpricot_scan.rl"
+#line 120 "hpricot_scan.rl"
 	{ mark_akey = p; }
 	goto st82;
 tr337:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 127 "hpricot_scan.rl"
+#line 135 "hpricot_scan.rl"
 	{
     akey = Qnil;
     aval = Qnil;
     mark_akey = NULL;
     mark_aval = NULL;
   }
-#line 112 "hpricot_scan.rl"
+#line 120 "hpricot_scan.rl"
 	{ mark_akey = p; }
 	goto st82;
 st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 2505 "hpricot_scan.c"
+#line 2513 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto tr175;
 		case 34: goto tr169;
@@ -2525,20 +2533,20 @@ case 82:
 		goto st82;
 	goto st80;
 tr175:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
 	goto st83;
 tr206:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st83;
 tr200:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -2548,7 +2556,7 @@ st83:
 	if ( ++p == pe )
 		goto _test_eof83;
 case 83:
-#line 2552 "hpricot_scan.c"
+#line 2560 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st83;
 		case 34: goto tr169;
@@ -2572,9 +2580,9 @@ case 83:
 		goto tr170;
 	goto st80;
 tr177:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -2582,7 +2590,7 @@ tr177:
   }
 	goto st84;
 tr171:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -2590,9 +2598,9 @@ tr171:
   }
 	goto st84;
 tr338:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -2603,7 +2611,7 @@ st84:
 	if ( ++p == pe )
 		goto _test_eof84;
 case 84:
-#line 2607 "hpricot_scan.c"
+#line 2615 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 34: goto tr169;
 		case 62: goto tr182;
@@ -2613,14 +2621,14 @@ case 84:
 tr158:
 #line 1 "NONE"
 	{te = p+1;}
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -2632,12 +2640,12 @@ tr158:
 tr166:
 #line 1 "NONE"
 	{te = p+1;}
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -2649,7 +2657,7 @@ tr166:
 tr172:
 #line 1 "NONE"
 	{te = p+1;}
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -2661,9 +2669,9 @@ tr172:
 tr179:
 #line 1 "NONE"
 	{te = p+1;}
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -2681,13 +2689,13 @@ tr182:
 tr196:
 #line 1 "NONE"
 	{te = p+1;}
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -2698,15 +2706,15 @@ tr196:
 tr197:
 #line 1 "NONE"
 	{te = p+1;}
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -2717,14 +2725,14 @@ tr197:
 tr205:
 #line 1 "NONE"
 	{te = p+1;}
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -2736,9 +2744,9 @@ tr205:
 tr339:
 #line 1 "NONE"
 	{te = p+1;}
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -2751,21 +2759,21 @@ st209:
 	if ( ++p == pe )
 		goto _test_eof209;
 case 209:
-#line 2755 "hpricot_scan.c"
+#line 2763 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 34: goto tr169;
 		case 92: goto st81;
 	}
 	goto st80;
 tr178:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
 	goto st85;
 st85:
 	if ( ++p == pe )
 		goto _test_eof85;
 case 85:
-#line 2769 "hpricot_scan.c"
+#line 2777 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr183;
 		case 32: goto tr183;
@@ -2783,14 +2791,14 @@ case 85:
 		goto tr183;
 	goto tr152;
 tr183:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st86;
 st86:
 	if ( ++p == pe )
 		goto _test_eof86;
 case 86:
-#line 2794 "hpricot_scan.c"
+#line 2802 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr188;
 		case 32: goto tr188;
@@ -2808,13 +2816,13 @@ case 86:
 		goto tr188;
 	goto tr152;
 tr188:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st87;
 tr191:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -2824,7 +2832,7 @@ st87:
 	if ( ++p == pe )
 		goto _test_eof87;
 case 87:
-#line 2828 "hpricot_scan.c"
+#line 2836 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr188;
 		case 32: goto tr188;
@@ -2853,13 +2861,13 @@ case 87:
 		goto tr190;
 	goto tr152;
 tr189:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st88;
 tr192:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -2869,7 +2877,7 @@ st88:
 	if ( ++p == pe )
 		goto _test_eof88;
 case 88:
-#line 2873 "hpricot_scan.c"
+#line 2881 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr191;
 		case 32: goto tr191;
@@ -2898,14 +2906,14 @@ case 88:
 		goto tr190;
 	goto tr152;
 tr193:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st89;
 st89:
 	if ( ++p == pe )
 		goto _test_eof89;
 case 89:
-#line 2909 "hpricot_scan.c"
+#line 2917 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr153;
 		case 32: goto tr153;
@@ -2933,36 +2941,36 @@ case 89:
 		goto tr190;
 	goto tr152;
 tr162:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st90;
 tr154:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st90;
 tr214:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st90;
 tr209:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st90;
 st90:
 	if ( ++p == pe )
 		goto _test_eof90;
 case 90:
-#line 2966 "hpricot_scan.c"
+#line 2974 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr161;
 		case 32: goto tr161;
@@ -2990,46 +2998,46 @@ case 90:
 		goto tr198;
 	goto st78;
 tr198:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 127 "hpricot_scan.rl"
+#line 135 "hpricot_scan.rl"
 	{
     akey = Qnil;
     aval = Qnil;
     mark_akey = NULL;
     mark_aval = NULL;
   }
-#line 112 "hpricot_scan.rl"
+#line 120 "hpricot_scan.rl"
 	{ mark_akey = p; }
 	goto st91;
 tr190:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 127 "hpricot_scan.rl"
+#line 135 "hpricot_scan.rl"
 	{
     akey = Qnil;
     aval = Qnil;
     mark_akey = NULL;
     mark_aval = NULL;
   }
-#line 112 "hpricot_scan.rl"
+#line 120 "hpricot_scan.rl"
 	{ mark_akey = p; }
 	goto st91;
 st91:
 	if ( ++p == pe )
 		goto _test_eof91;
 case 91:
-#line 3033 "hpricot_scan.c"
+#line 3041 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr200;
 		case 32: goto tr200;
@@ -3058,16 +3066,16 @@ case 91:
 		goto st91;
 	goto st78;
 tr207:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st92;
 tr201:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -3077,7 +3085,7 @@ st92:
 	if ( ++p == pe )
 		goto _test_eof92;
 case 92:
-#line 3081 "hpricot_scan.c"
+#line 3089 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr206;
 		case 32: goto tr206;
@@ -3106,9 +3114,9 @@ case 92:
 		goto tr198;
 	goto st78;
 tr187:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -3116,12 +3124,12 @@ tr187:
   }
 	goto st93;
 tr164:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -3129,27 +3137,27 @@ tr164:
   }
 	goto st93;
 tr199:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st93;
 tr203:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -3157,14 +3165,14 @@ tr203:
   }
 	goto st93;
 tr156:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -3172,15 +3180,15 @@ tr156:
   }
 	goto st93;
 tr195:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -3190,7 +3198,7 @@ st93:
 	if ( ++p == pe )
 		goto _test_eof93;
 case 93:
-#line 3194 "hpricot_scan.c"
+#line 3202 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr161;
 		case 32: goto tr161;
@@ -3207,14 +3215,14 @@ case 93:
 		goto tr161;
 	goto st78;
 tr159:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st94;
 st94:
 	if ( ++p == pe )
 		goto _test_eof94;
 case 94:
-#line 3218 "hpricot_scan.c"
+#line 3226 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr161;
 		case 32: goto tr161;
@@ -3231,18 +3239,18 @@ case 94:
 		goto tr161;
 	goto st78;
 tr184:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st95;
 tr204:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
 	goto st95;
 st95:
 	if ( ++p == pe )
 		goto _test_eof95;
 case 95:
-#line 3246 "hpricot_scan.c"
+#line 3254 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr191;
 		case 32: goto tr191;
@@ -3280,14 +3288,14 @@ case 96:
 		goto tr211;
 	goto tr210;
 tr210:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st97;
 st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-#line 3291 "hpricot_scan.c"
+#line 3299 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr220;
 		case 32: goto tr220;
@@ -3305,34 +3313,34 @@ case 97:
 		goto tr220;
 	goto st97;
 tr315:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st98;
 tr220:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st98;
 tr211:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st98;
 tr299:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st98;
 st98:
 	if ( ++p == pe )
 		goto _test_eof98;
 case 98:
-#line 3336 "hpricot_scan.c"
+#line 3344 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st98;
 		case 34: goto tr228;
@@ -3356,14 +3364,14 @@ case 98:
 		goto tr229;
 	goto st99;
 tr216:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st99;
 st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-#line 3367 "hpricot_scan.c"
+#line 3375 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 34: goto tr228;
 		case 39: goto tr174;
@@ -3371,46 +3379,46 @@ case 99:
 	}
 	goto st99;
 tr330:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st100;
 tr255:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st100;
 tr326:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st100;
 tr316:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st100;
 tr228:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st100;
 tr322:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st100;
 st100:
 	if ( ++p == pe )
 		goto _test_eof100;
 case 100:
-#line 3414 "hpricot_scan.c"
+#line 3422 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st100;
 		case 39: goto tr169;
@@ -3433,74 +3441,74 @@ case 100:
 		goto tr235;
 	goto st101;
 tr328:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st101;
 st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3444 "hpricot_scan.c"
+#line 3452 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 39: goto tr169;
 		case 92: goto st102;
 	}
 	goto st101;
 tr335:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st102;
 st102:
 	if ( ++p == pe )
 		goto _test_eof102;
 case 102:
-#line 3458 "hpricot_scan.c"
+#line 3466 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 39: goto tr228;
 		case 92: goto st102;
 	}
 	goto st101;
 tr235:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 127 "hpricot_scan.rl"
+#line 135 "hpricot_scan.rl"
 	{
     akey = Qnil;
     aval = Qnil;
     mark_akey = NULL;
     mark_aval = NULL;
   }
-#line 112 "hpricot_scan.rl"
+#line 120 "hpricot_scan.rl"
 	{ mark_akey = p; }
 	goto st103;
 tr332:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 127 "hpricot_scan.rl"
+#line 135 "hpricot_scan.rl"
 	{
     akey = Qnil;
     aval = Qnil;
     mark_akey = NULL;
     mark_aval = NULL;
   }
-#line 112 "hpricot_scan.rl"
+#line 120 "hpricot_scan.rl"
 	{ mark_akey = p; }
 	goto st103;
 st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
-#line 3504 "hpricot_scan.c"
+#line 3512 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto tr239;
 		case 39: goto tr169;
@@ -3524,20 +3532,20 @@ case 103:
 		goto st103;
 	goto st101;
 tr239:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
 	goto st104;
 tr269:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st104;
 tr263:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -3547,7 +3555,7 @@ st104:
 	if ( ++p == pe )
 		goto _test_eof104;
 case 104:
-#line 3551 "hpricot_scan.c"
+#line 3559 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st104;
 		case 39: goto tr169;
@@ -3571,9 +3579,9 @@ case 104:
 		goto tr235;
 	goto st101;
 tr241:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -3581,7 +3589,7 @@ tr241:
   }
 	goto st105;
 tr236:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -3589,9 +3597,9 @@ tr236:
   }
 	goto st105;
 tr333:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -3602,7 +3610,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3606 "hpricot_scan.c"
+#line 3614 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 39: goto tr169;
 		case 62: goto tr246;
@@ -3612,14 +3620,14 @@ case 105:
 tr341:
 #line 1 "NONE"
 	{te = p+1;}
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -3631,12 +3639,12 @@ tr341:
 tr258:
 #line 1 "NONE"
 	{te = p+1;}
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -3648,7 +3656,7 @@ tr258:
 tr237:
 #line 1 "NONE"
 	{te = p+1;}
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -3660,9 +3668,9 @@ tr237:
 tr243:
 #line 1 "NONE"
 	{te = p+1;}
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -3680,13 +3688,13 @@ tr246:
 tr262:
 #line 1 "NONE"
 	{te = p+1;}
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -3697,15 +3705,15 @@ tr262:
 tr329:
 #line 1 "NONE"
 	{te = p+1;}
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -3716,14 +3724,14 @@ tr329:
 tr268:
 #line 1 "NONE"
 	{te = p+1;}
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -3735,9 +3743,9 @@ tr268:
 tr334:
 #line 1 "NONE"
 	{te = p+1;}
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -3750,21 +3758,21 @@ st210:
 	if ( ++p == pe )
 		goto _test_eof210;
 case 210:
-#line 3754 "hpricot_scan.c"
+#line 3762 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 39: goto tr169;
 		case 92: goto st102;
 	}
 	goto st101;
 tr242:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
 	goto st106;
 st106:
 	if ( ++p == pe )
 		goto _test_eof106;
 case 106:
-#line 3768 "hpricot_scan.c"
+#line 3776 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr248;
 		case 32: goto tr248;
@@ -3782,14 +3790,14 @@ case 106:
 		goto tr248;
 	goto tr247;
 tr247:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st107;
 st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 3793 "hpricot_scan.c"
+#line 3801 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr255;
 		case 32: goto tr255;
@@ -3806,42 +3814,42 @@ case 107:
 		goto tr255;
 	goto st107;
 tr256:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st108;
 tr327:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st108;
 tr281:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st108;
 tr222:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st108;
 tr213:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st108;
 st108:
 	if ( ++p == pe )
 		goto _test_eof108;
 case 108:
-#line 3845 "hpricot_scan.c"
+#line 3853 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr255;
 		case 32: goto tr255;
@@ -3869,46 +3877,46 @@ case 108:
 		goto tr260;
 	goto st107;
 tr260:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 127 "hpricot_scan.rl"
+#line 135 "hpricot_scan.rl"
 	{
     akey = Qnil;
     aval = Qnil;
     mark_akey = NULL;
     mark_aval = NULL;
   }
-#line 112 "hpricot_scan.rl"
+#line 120 "hpricot_scan.rl"
 	{ mark_akey = p; }
 	goto st109;
 tr279:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 127 "hpricot_scan.rl"
+#line 135 "hpricot_scan.rl"
 	{
     akey = Qnil;
     aval = Qnil;
     mark_akey = NULL;
     mark_aval = NULL;
   }
-#line 112 "hpricot_scan.rl"
+#line 120 "hpricot_scan.rl"
 	{ mark_akey = p; }
 	goto st109;
 st109:
 	if ( ++p == pe )
 		goto _test_eof109;
 case 109:
-#line 3912 "hpricot_scan.c"
+#line 3920 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr263;
 		case 32: goto tr263;
@@ -3937,16 +3945,16 @@ case 109:
 		goto st109;
 	goto st107;
 tr270:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st110;
 tr264:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -3956,7 +3964,7 @@ st110:
 	if ( ++p == pe )
 		goto _test_eof110;
 case 110:
-#line 3960 "hpricot_scan.c"
+#line 3968 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr269;
 		case 32: goto tr269;
@@ -3985,9 +3993,9 @@ case 110:
 		goto tr260;
 	goto st107;
 tr252:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -3995,12 +4003,12 @@ tr252:
   }
 	goto st111;
 tr257:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -4008,27 +4016,27 @@ tr257:
   }
 	goto st111;
 tr261:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st111;
 tr266:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -4036,14 +4044,14 @@ tr266:
   }
 	goto st111;
 tr276:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -4051,15 +4059,15 @@ tr276:
   }
 	goto st111;
 tr280:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -4069,7 +4077,7 @@ st111:
 	if ( ++p == pe )
 		goto _test_eof111;
 case 111:
-#line 4073 "hpricot_scan.c"
+#line 4081 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr255;
 		case 32: goto tr255;
@@ -4086,14 +4094,14 @@ case 111:
 		goto tr255;
 	goto st107;
 tr253:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st112;
 st112:
 	if ( ++p == pe )
 		goto _test_eof112;
 case 112:
-#line 4097 "hpricot_scan.c"
+#line 4105 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr255;
 		case 32: goto tr255;
@@ -4110,18 +4118,18 @@ case 112:
 		goto tr255;
 	goto st107;
 tr249:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st113;
 tr267:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
 	goto st113;
 st113:
 	if ( ++p == pe )
 		goto _test_eof113;
 case 113:
-#line 4125 "hpricot_scan.c"
+#line 4133 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr272;
 		case 32: goto tr272;
@@ -4139,13 +4147,13 @@ case 113:
 		goto tr272;
 	goto tr247;
 tr277:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st114;
 tr272:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -4155,7 +4163,7 @@ st114:
 	if ( ++p == pe )
 		goto _test_eof114;
 case 114:
-#line 4159 "hpricot_scan.c"
+#line 4167 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr277;
 		case 32: goto tr277;
@@ -4184,13 +4192,13 @@ case 114:
 		goto tr279;
 	goto tr247;
 tr278:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st115;
 tr273:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -4200,7 +4208,7 @@ st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 4204 "hpricot_scan.c"
+#line 4212 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr272;
 		case 32: goto tr272;
@@ -4249,30 +4257,30 @@ case 116:
 		goto tr211;
 	goto tr210;
 tr221:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st117;
 tr212:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st117;
 tr314:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st117;
 st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 4276 "hpricot_scan.c"
+#line 4284 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr220;
 		case 32: goto tr220;
@@ -4301,46 +4309,46 @@ case 117:
 		goto tr282;
 	goto st97;
 tr282:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 127 "hpricot_scan.rl"
+#line 135 "hpricot_scan.rl"
 	{
     akey = Qnil;
     aval = Qnil;
     mark_akey = NULL;
     mark_aval = NULL;
   }
-#line 112 "hpricot_scan.rl"
+#line 120 "hpricot_scan.rl"
 	{ mark_akey = p; }
 	goto st118;
 tr307:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 127 "hpricot_scan.rl"
+#line 135 "hpricot_scan.rl"
 	{
     akey = Qnil;
     aval = Qnil;
     mark_akey = NULL;
     mark_aval = NULL;
   }
-#line 112 "hpricot_scan.rl"
+#line 120 "hpricot_scan.rl"
 	{ mark_akey = p; }
 	goto st118;
 st118:
 	if ( ++p == pe )
 		goto _test_eof118;
 case 118:
-#line 4344 "hpricot_scan.c"
+#line 4352 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr285;
 		case 32: goto tr285;
@@ -4370,20 +4378,20 @@ case 118:
 		goto st118;
 	goto st97;
 tr293:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
 	goto st119;
 tr323:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st119;
 tr285:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -4393,7 +4401,7 @@ st119:
 	if ( ++p == pe )
 		goto _test_eof119;
 case 119:
-#line 4397 "hpricot_scan.c"
+#line 4405 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st119;
 		case 34: goto tr228;
@@ -4418,46 +4426,46 @@ case 119:
 		goto tr229;
 	goto st99;
 tr229:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 127 "hpricot_scan.rl"
+#line 135 "hpricot_scan.rl"
 	{
     akey = Qnil;
     aval = Qnil;
     mark_akey = NULL;
     mark_aval = NULL;
   }
-#line 112 "hpricot_scan.rl"
+#line 120 "hpricot_scan.rl"
 	{ mark_akey = p; }
 	goto st120;
 tr318:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 127 "hpricot_scan.rl"
+#line 135 "hpricot_scan.rl"
 	{
     akey = Qnil;
     aval = Qnil;
     mark_akey = NULL;
     mark_aval = NULL;
   }
-#line 112 "hpricot_scan.rl"
+#line 120 "hpricot_scan.rl"
 	{ mark_akey = p; }
 	goto st120;
 st120:
 	if ( ++p == pe )
 		goto _test_eof120;
 case 120:
-#line 4461 "hpricot_scan.c"
+#line 4469 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto tr293;
 		case 34: goto tr228;
@@ -4482,9 +4490,9 @@ case 120:
 		goto st120;
 	goto st99;
 tr295:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -4492,7 +4500,7 @@ tr295:
   }
 	goto st121;
 tr230:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -4500,9 +4508,9 @@ tr230:
   }
 	goto st121;
 tr319:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -4513,7 +4521,7 @@ st121:
 	if ( ++p == pe )
 		goto _test_eof121;
 case 121:
-#line 4517 "hpricot_scan.c"
+#line 4525 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 34: goto tr228;
 		case 39: goto tr174;
@@ -4524,14 +4532,14 @@ case 121:
 tr217:
 #line 1 "NONE"
 	{te = p+1;}
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -4543,12 +4551,12 @@ tr217:
 tr225:
 #line 1 "NONE"
 	{te = p+1;}
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -4560,7 +4568,7 @@ tr225:
 tr231:
 #line 1 "NONE"
 	{te = p+1;}
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -4572,9 +4580,9 @@ tr231:
 tr297:
 #line 1 "NONE"
 	{te = p+1;}
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -4592,13 +4600,13 @@ tr298:
 tr284:
 #line 1 "NONE"
 	{te = p+1;}
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -4609,15 +4617,15 @@ tr284:
 tr313:
 #line 1 "NONE"
 	{te = p+1;}
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -4628,14 +4636,14 @@ tr313:
 tr290:
 #line 1 "NONE"
 	{te = p+1;}
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -4647,9 +4655,9 @@ tr290:
 tr320:
 #line 1 "NONE"
 	{te = p+1;}
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -4662,7 +4670,7 @@ st211:
 	if ( ++p == pe )
 		goto _test_eof211;
 case 211:
-#line 4666 "hpricot_scan.c"
+#line 4674 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 34: goto tr228;
 		case 39: goto tr174;
@@ -4670,14 +4678,14 @@ case 211:
 	}
 	goto st99;
 tr321:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st122;
 st122:
 	if ( ++p == pe )
 		goto _test_eof122;
 case 122:
-#line 4681 "hpricot_scan.c"
+#line 4689 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 34: goto tr299;
 		case 39: goto tr299;
@@ -4685,14 +4693,14 @@ case 122:
 	}
 	goto st99;
 tr296:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
 	goto st123;
 st123:
 	if ( ++p == pe )
 		goto _test_eof123;
 case 123:
-#line 4696 "hpricot_scan.c"
+#line 4704 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr300;
 		case 32: goto tr300;
@@ -4710,14 +4718,14 @@ case 123:
 		goto tr300;
 	goto tr210;
 tr300:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st124;
 st124:
 	if ( ++p == pe )
 		goto _test_eof124;
 case 124:
-#line 4721 "hpricot_scan.c"
+#line 4729 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr305;
 		case 32: goto tr305;
@@ -4735,13 +4743,13 @@ case 124:
 		goto tr305;
 	goto tr210;
 tr305:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st125;
 tr308:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -4751,7 +4759,7 @@ st125:
 	if ( ++p == pe )
 		goto _test_eof125;
 case 125:
-#line 4755 "hpricot_scan.c"
+#line 4763 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr305;
 		case 32: goto tr305;
@@ -4780,13 +4788,13 @@ case 125:
 		goto tr307;
 	goto tr210;
 tr306:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st126;
 tr309:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -4796,7 +4804,7 @@ st126:
 	if ( ++p == pe )
 		goto _test_eof126;
 case 126:
-#line 4800 "hpricot_scan.c"
+#line 4808 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr308;
 		case 32: goto tr308;
@@ -4825,14 +4833,14 @@ case 126:
 		goto tr307;
 	goto tr210;
 tr310:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st127;
 st127:
 	if ( ++p == pe )
 		goto _test_eof127;
 case 127:
-#line 4836 "hpricot_scan.c"
+#line 4844 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr211;
 		case 32: goto tr211;
@@ -4861,9 +4869,9 @@ case 127:
 		goto tr307;
 	goto tr210;
 tr304:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -4871,12 +4879,12 @@ tr304:
   }
 	goto st128;
 tr223:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -4884,27 +4892,27 @@ tr223:
   }
 	goto st128;
 tr283:
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st128;
 tr288:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -4912,14 +4920,14 @@ tr288:
   }
 	goto st128;
 tr215:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
@@ -4927,15 +4935,15 @@ tr215:
   }
 	goto st128;
 tr312:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
-#line 134 "hpricot_scan.rl"
+#line 142 "hpricot_scan.rl"
 	{
     if (!S->xml)
       akey = rb_funcall(akey, s_downcase, 0);
     ATTR(akey, aval);
   }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -4945,7 +4953,7 @@ st128:
 	if ( ++p == pe )
 		goto _test_eof128;
 case 128:
-#line 4949 "hpricot_scan.c"
+#line 4957 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr220;
 		case 32: goto tr220;
@@ -4963,14 +4971,14 @@ case 128:
 		goto tr220;
 	goto st97;
 tr218:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st129;
 st129:
 	if ( ++p == pe )
 		goto _test_eof129;
 case 129:
-#line 4974 "hpricot_scan.c"
+#line 4982 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr220;
 		case 32: goto tr220;
@@ -4988,14 +4996,14 @@ case 129:
 		goto tr220;
 	goto st97;
 tr311:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st130;
 st130:
 	if ( ++p == pe )
 		goto _test_eof130;
 case 130:
-#line 4999 "hpricot_scan.c"
+#line 5007 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr211;
 		case 32: goto tr211;
@@ -5024,14 +5032,14 @@ case 130:
 		goto tr307;
 	goto tr210;
 tr302:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st131;
 st131:
 	if ( ++p == pe )
 		goto _test_eof131;
 case 131:
-#line 5035 "hpricot_scan.c"
+#line 5043 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto tr315;
 		case 34: goto tr316;
@@ -5055,14 +5063,14 @@ case 131:
 		goto tr318;
 	goto tr216;
 tr303:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st132;
 st132:
 	if ( ++p == pe )
 		goto _test_eof132;
 case 132:
-#line 5066 "hpricot_scan.c"
+#line 5074 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto tr315;
 		case 34: goto tr322;
@@ -5086,18 +5094,18 @@ case 132:
 		goto tr318;
 	goto tr216;
 tr301:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st133;
 tr289:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
 	goto st133;
 st133:
 	if ( ++p == pe )
 		goto _test_eof133;
 case 133:
-#line 5101 "hpricot_scan.c"
+#line 5109 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr308;
 		case 32: goto tr308;
@@ -5115,16 +5123,16 @@ case 133:
 		goto tr308;
 	goto tr210;
 tr324:
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
   }
 	goto st134;
 tr286:
-#line 120 "hpricot_scan.rl"
+#line 128 "hpricot_scan.rl"
 	{ SET(akey, p); }
-#line 116 "hpricot_scan.rl"
+#line 124 "hpricot_scan.rl"
 	{
     if (*(p-1) == '"' || *(p-1) == '\'') { SET(aval, p-1); }
     else { SET(aval, p); }
@@ -5134,7 +5142,7 @@ st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 5138 "hpricot_scan.c"
+#line 5146 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr323;
 		case 32: goto tr323;
@@ -5164,14 +5172,14 @@ case 134:
 		goto tr282;
 	goto st97;
 tr275:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st135;
 st135:
 	if ( ++p == pe )
 		goto _test_eof135;
 case 135:
-#line 5175 "hpricot_scan.c"
+#line 5183 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr326;
 		case 32: goto tr326;
@@ -5209,14 +5217,14 @@ case 136:
 	}
 	goto tr216;
 tr251:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st137;
 st137:
 	if ( ++p == pe )
 		goto _test_eof137;
 case 137:
-#line 5220 "hpricot_scan.c"
+#line 5228 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto tr330;
 		case 39: goto tr331;
@@ -5239,14 +5247,14 @@ case 137:
 		goto tr332;
 	goto tr328;
 tr248:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st138;
 st138:
 	if ( ++p == pe )
 		goto _test_eof138;
 case 138:
-#line 5250 "hpricot_scan.c"
+#line 5258 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr277;
 		case 32: goto tr277;
@@ -5264,14 +5272,14 @@ case 138:
 		goto tr277;
 	goto tr247;
 tr185:
-#line 115 "hpricot_scan.rl"
+#line 123 "hpricot_scan.rl"
 	{ SET(aval, p); }
 	goto st139;
 st139:
 	if ( ++p == pe )
 		goto _test_eof139;
 case 139:
-#line 5275 "hpricot_scan.c"
+#line 5283 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto tr336;
 		case 34: goto tr331;
@@ -5341,14 +5349,14 @@ case 143:
 	}
 	goto tr328;
 tr120:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st144;
 st144:
 	if ( ++p == pe )
 		goto _test_eof144;
 case 144:
-#line 5352 "hpricot_scan.c"
+#line 5360 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 13: goto tr148;
 		case 32: goto tr148;
@@ -5387,7 +5395,7 @@ st146:
 	if ( ++p == pe )
 		goto _test_eof146;
 case 146:
-#line 5391 "hpricot_scan.c"
+#line 5399 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st212;
 		case 63: goto st146;
@@ -5425,7 +5433,7 @@ st147:
 	if ( ++p == pe )
 		goto _test_eof147;
 case 147:
-#line 5429 "hpricot_scan.c"
+#line 5437 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st212;
 		case 63: goto st146;
@@ -5504,7 +5512,7 @@ st213:
 	if ( ++p == pe )
 		goto _test_eof213;
 case 213:
-#line 5508 "hpricot_scan.c"
+#line 5516 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto tr348;
 		case 118: goto st150;
@@ -5596,14 +5604,14 @@ case 158:
 		goto tr359;
 	goto tr349;
 tr359:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st159;
 st159:
 	if ( ++p == pe )
 		goto _test_eof159;
 case 159:
-#line 5607 "hpricot_scan.c"
+#line 5615 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 34: goto tr360;
 		case 95: goto st159;
@@ -5621,14 +5629,14 @@ case 159:
 		goto st159;
 	goto tr349;
 tr360:
-#line 121 "hpricot_scan.rl"
+#line 129 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("version")), aval); }
 	goto st160;
 st160:
 	if ( ++p == pe )
 		goto _test_eof160;
 case 160:
-#line 5632 "hpricot_scan.c"
+#line 5640 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st161;
 		case 62: goto tr363;
@@ -5741,14 +5749,14 @@ case 172:
 		goto tr377;
 	goto tr349;
 tr377:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st173;
 st173:
 	if ( ++p == pe )
 		goto _test_eof173;
 case 173:
-#line 5752 "hpricot_scan.c"
+#line 5760 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 34: goto tr378;
 		case 95: goto st173;
@@ -5766,14 +5774,14 @@ case 173:
 		goto st173;
 	goto tr349;
 tr378:
-#line 122 "hpricot_scan.rl"
+#line 130 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("encoding")), aval); }
 	goto st174;
 st174:
 	if ( ++p == pe )
 		goto _test_eof174;
 case 174:
-#line 5777 "hpricot_scan.c"
+#line 5785 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st175;
 		case 62: goto tr363;
@@ -5891,14 +5899,14 @@ case 187:
 	}
 	goto tr349;
 tr393:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st188;
 st188:
 	if ( ++p == pe )
 		goto _test_eof188;
 case 188:
-#line 5902 "hpricot_scan.c"
+#line 5910 "hpricot_scan.c"
 	if ( (*p) == 111 )
 		goto st189;
 	goto tr349;
@@ -5910,14 +5918,14 @@ case 189:
 		goto tr396;
 	goto tr349;
 tr396:
-#line 123 "hpricot_scan.rl"
+#line 131 "hpricot_scan.rl"
 	{ SET(aval, p); ATTR(ID2SYM(rb_intern("standalone")), aval); }
 	goto st190;
 st190:
 	if ( ++p == pe )
 		goto _test_eof190;
 case 190:
-#line 5921 "hpricot_scan.c"
+#line 5929 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 32: goto st190;
 		case 62: goto tr363;
@@ -5927,14 +5935,14 @@ case 190:
 		goto st190;
 	goto tr349;
 tr394:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st191;
 st191:
 	if ( ++p == pe )
 		goto _test_eof191;
 case 191:
-#line 5938 "hpricot_scan.c"
+#line 5946 "hpricot_scan.c"
 	if ( (*p) == 101 )
 		goto st192;
 	goto tr349;
@@ -5955,14 +5963,14 @@ case 193:
 	}
 	goto tr349;
 tr399:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st194;
 st194:
 	if ( ++p == pe )
 		goto _test_eof194;
 case 194:
-#line 5966 "hpricot_scan.c"
+#line 5974 "hpricot_scan.c"
 	if ( (*p) == 111 )
 		goto st195;
 	goto tr349;
@@ -5974,14 +5982,14 @@ case 195:
 		goto tr396;
 	goto tr349;
 tr400:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st196;
 st196:
 	if ( ++p == pe )
 		goto _test_eof196;
 case 196:
-#line 5985 "hpricot_scan.c"
+#line 5993 "hpricot_scan.c"
 	if ( (*p) == 101 )
 		goto st197;
 	goto tr349;
@@ -6003,14 +6011,14 @@ case 198:
 		goto tr403;
 	goto tr349;
 tr403:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st199;
 st199:
 	if ( ++p == pe )
 		goto _test_eof199;
 case 199:
-#line 6014 "hpricot_scan.c"
+#line 6022 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 39: goto tr378;
 		case 95: goto st199;
@@ -6046,14 +6054,14 @@ case 200:
 		goto tr405;
 	goto tr349;
 tr405:
-#line 111 "hpricot_scan.rl"
+#line 119 "hpricot_scan.rl"
 	{ mark_aval = p; }
 	goto st201;
 st201:
 	if ( ++p == pe )
 		goto _test_eof201;
 case 201:
-#line 6057 "hpricot_scan.c"
+#line 6065 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 39: goto tr360;
 		case 95: goto st201;
@@ -6102,7 +6110,7 @@ st214:
 case 214:
 #line 1 "NONE"
 	{ts = p;}
-#line 6106 "hpricot_scan.c"
+#line 6114 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 10: goto tr423;
 		case 45: goto tr424;
@@ -6116,7 +6124,7 @@ st215:
 	if ( ++p == pe )
 		goto _test_eof215;
 case 215:
-#line 6120 "hpricot_scan.c"
+#line 6128 "hpricot_scan.c"
 	if ( (*p) == 45 )
 		goto st202;
 	goto tr425;
@@ -6159,7 +6167,7 @@ st216:
 case 216:
 #line 1 "NONE"
 	{ts = p;}
-#line 6163 "hpricot_scan.c"
+#line 6171 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 10: goto tr428;
 		case 93: goto tr429;
@@ -6173,7 +6181,7 @@ st217:
 	if ( ++p == pe )
 		goto _test_eof217;
 case 217:
-#line 6177 "hpricot_scan.c"
+#line 6185 "hpricot_scan.c"
 	if ( (*p) == 93 )
 		goto st203;
 	goto tr430;
@@ -6212,7 +6220,7 @@ st218:
 case 218:
 #line 1 "NONE"
 	{ts = p;}
-#line 6216 "hpricot_scan.c"
+#line 6224 "hpricot_scan.c"
 	switch( (*p) ) {
 		case 10: goto tr433;
 		case 62: goto tr434;
@@ -6673,7 +6681,7 @@ case 219:
 
 	}
 
-#line 534 "hpricot_scan.rl"
+#line 542 "hpricot_scan.rl"
 
     if (cs == hpricot_scan_error) {
       if (buf != NULL)
@@ -6748,34 +6756,68 @@ case 219:
   return Qnil;
 }
 
-static VALUE
-alloc_hpricot_struct(VALUE klass)
-{
-  VALUE size;
-  long n;
-  NEWOBJ(st, struct RStruct);
-  OBJSETUP(st, klass, T_STRUCT);
+void hstruct_mark(void* ptr) {
+  struct hpricot_struct* st = (struct hpricot_struct*)ptr;
+  int i;
 
-  size = rb_struct_iv_get(klass, "__size__");
-  n = FIX2LONG(size);
-
-#ifndef RSTRUCT_EMBED_LEN_MAX
-  st->ptr = ALLOC_N(VALUE, n);
-  rb_mem_clear(st->ptr, n);
-  st->len = n;
-#else
-  if (0 < n && n <= RSTRUCT_EMBED_LEN_MAX) {
-    RBASIC(st)->flags &= ~RSTRUCT_EMBED_LEN_MASK;
-    RBASIC(st)->flags |= n << RSTRUCT_EMBED_LEN_SHIFT;
-    rb_mem_clear(st->as.ary, n);
-  } else {
-    st->as.heap.ptr = ALLOC_N(VALUE, n);
-    rb_mem_clear(st->as.heap.ptr, n);
-    st->as.heap.len = n;
+  for(i = 0; i < st->len; i++) {
+    rb_gc_mark(st->ptr[i]);
   }
-#endif
+}
 
-  return (VALUE)st;
+void hstruct_free(void* ptr) {
+  struct hpricot_struct* st = (struct hpricot_struct*)ptr;
+
+  XFREE(st->ptr);
+  XFREE(st);
+}
+
+static VALUE
+alloc_hpricot_struct8(VALUE klass)
+{
+  VALUE obj;
+  struct hpricot_struct* st;
+
+  obj = Data_Make_Struct(klass, struct hpricot_struct, hstruct_mark, hstruct_free, st);
+
+  st->len = 8;
+  st->ptr = ALLOC_N(VALUE, 8);
+
+  rb_mem_clear(st->ptr, 8);
+
+  return obj;
+}
+
+static VALUE
+alloc_hpricot_struct2(VALUE klass)
+{
+  VALUE obj;
+  struct hpricot_struct* st;
+
+  obj = Data_Make_Struct(klass, struct hpricot_struct, hstruct_mark, hstruct_free, st);
+
+  st->len = 2;
+  st->ptr = ALLOC_N(VALUE, 2);
+
+  rb_mem_clear(st->ptr, 2);
+
+  return obj;
+}
+
+static VALUE
+alloc_hpricot_struct3(VALUE klass)
+{
+  VALUE obj;
+  struct hpricot_struct* st;
+
+  obj = Data_Make_Struct(klass, struct hpricot_struct, hstruct_mark, hstruct_free, st);
+
+  st->len = 3;
+  st->ptr = ALLOC_N(VALUE, 3);
+
+  rb_mem_clear(st->ptr, 3);
+
+  return obj;
 }
 
 static VALUE hpricot_struct_ref0(VALUE obj) {return H_ELE_GET(obj, 0);}
@@ -6827,17 +6869,28 @@ static VALUE (*set_func[10])() = {
 };
 
 static VALUE
-make_hpricot_struct(VALUE members)
+make_hpricot_struct(VALUE members, VALUE (*alloc)(VALUE klass))
 {
   int i = 0;
+  char attr_set[128];
+
   VALUE klass = rb_class_new(rb_cObject);
-  rb_iv_set(klass, "__size__", INT2NUM(RARRAY_LEN(members)));
-  rb_define_alloc_func(klass, alloc_hpricot_struct);
-  rb_define_singleton_method(klass, "new", rb_class_new_instance, -1);
-  for (i = 0; i < RARRAY_LEN(members); i++) {
-    ID id = SYM2ID(RARRAY_PTR(members)[i]);
-    rb_define_method_id(klass, id, ref_func[i], 0);
-    rb_define_method_id(klass, rb_id_attrset(id), set_func[i], 1);
+  rb_define_alloc_func(klass, alloc);
+
+  int len = RARRAY_LEN(members);
+  assert(len < 10);
+
+  for (i = 0; i < len; i++) {
+    ID id = SYM2ID(rb_ary_entry(members, i));
+    const char* name = rb_id2name(id);
+    int len = strlen(name);
+
+    memcpy(attr_set, name, strlen(name));
+    attr_set[len] = '=';
+    attr_set[len+1] = 0;
+
+    rb_define_method(klass, name, ref_func[i], 0);
+    rb_define_method(klass, attr_set, set_func[i], 1);
   }
   return klass;
 }
@@ -6881,9 +6934,13 @@ void Init_hpricot_scan()
 
   structElem = make_hpricot_struct(rb_ary_new3(8, sym_name, sym_parent,
     sym_raw_attributes, sym_etag, sym_raw_string, sym_allowed,
-    sym_tagno, sym_children));
-  structAttr = make_hpricot_struct(rb_ary_new3(3, sym_name, sym_parent, sym_raw_attributes));
-  structBasic = make_hpricot_struct(rb_ary_new3(2, sym_name, sym_parent));
+    sym_tagno, sym_children), alloc_hpricot_struct8);
+  structAttr = make_hpricot_struct(
+      rb_ary_new3(3, sym_name, sym_parent, sym_raw_attributes),
+      alloc_hpricot_struct3);
+  structBasic = make_hpricot_struct(
+      rb_ary_new3(2, sym_name, sym_parent),
+      alloc_hpricot_struct2);
 
   cDoc = rb_define_class_under(mHpricot, "Doc", structElem);
   cCData = rb_define_class_under(mHpricot, "CData", structBasic);

--- a/lib/hpricot/elements.rb
+++ b/lib/hpricot/elements.rb
@@ -65,7 +65,11 @@ module Hpricot
     #
     # See Hpricot::Container::Trav.at for more.
     def at(expr, &blk)
-      search(expr, &blk).first
+      if expr.kind_of? Fixnum
+        super
+      else
+        search(expr, &blk)[0]
+      end
     end
     alias_method :%, :at
 


### PR DESCRIPTION
This cleans up the weird RSTRUCT stuff and uses the normal Data_Wrap_Struct idiom. It also makes sure that Elements#at doesn't break using it to fetch elements out Elements as an Array (this is critical for running on Rubinius).
