### PR TITLE
Segfault solved - can you review ?

### DIFF
--- a/ext/hpricot_scan/hpricot_scan.rl
+++ b/ext/hpricot_scan/hpricot_scan.rl
@@ -668,8 +668,14 @@ void hstruct_mark(void* ptr) {
   struct hpricot_struct* st = (struct hpricot_struct*)ptr;
   int i;
 
-  for(i = 0; i < st->len; i++) {
-    rb_gc_mark(st->ptr[i]);
+  /* it's likely to hit GC when allocating st->ptr.
+   * that should be checked to avoid segfault.
+   * and simply ignore it.
+   */
+  if (st->ptr) {
+    for(i = 0; i < st->len; i++) {
+      rb_gc_mark(st->ptr[i]);
+    }
   }
 }
 


### PR DESCRIPTION
Hi guys,

here's a patch for hpricot/hpricot#32. All the tests pass here, and the segfault doesn't occur anymore.

I had a Test::Unit testcase that did reproduce the issue and still exited after failure, instead of never leaving, but the test-case is not cross-platform (uses neversaydie and Process.fork), so I didn't incorporate it, but maybe we could...

You can find the test here: https://gist.github.com/806234

I'm a total newcomer to the hpricot source though - can anyone have another look before I merge this back into master ?

-- Thibaut
