### PR TITLE
Special characters in attribute selectors

### DIFF
--- a/test/test_paths.rb
+++ b/test/test_paths.rb
@@ -22,4 +22,15 @@ class TestParser < Test::Unit::TestCase
     doc = Hpricot('<input name="vendor[porkpies][meaty]"/>')
     assert_equal 1, (doc/'input[@name^="vendor[porkpies][meaty]"]').length
   end
+  # Colons should work according to:
+  # http://www.w3.org/TR/2000/REC-xml-20001006#NT-Name
+  def test_attr_double_colon
+    doc = Hpricot('<input name="11:00:00PM"/>')
+    assert_equal 1, (doc/'input[@name^="11:00:00PM"]').length
+  end
+  # This is not a name attribute, but it should not throw exceptions
+  def test_attr_exclamation_mark
+    doc = Hpricot('<input name="hello!"/>')
+    assert_equal 1, (doc/'input[@name^="hello!"]').length
+  end
 end


### PR DESCRIPTION
There seems to be a problem with special characters (like :: and !) when used in selectors like:
input[@name^="11:00:00PM"]

An unexpected exception is thrown.
I'm not sure how to fix this, so I added a test case.
