### PR TITLE
Special characters in attribute selectors

### DIFF
--- a/lib/hpricot/elements.rb
+++ b/lib/hpricot/elements.rb
@@ -295,6 +295,7 @@ module Hpricot
             elsif "#{m[0]}#{m[1]}" =~ /^(:first|:last)$/
                 nodes = [nodes.send(m[1])]
             else
+                args = []
                 meth = "filter[#{m[0]}#{m[1]}]" unless m[0].empty?
                 if meth and Traverse.method_defined? meth
                     args = m[2..-1]

--- a/test/test_paths.rb
+++ b/test/test_paths.rb
@@ -22,4 +22,15 @@ class TestParser < Test::Unit::TestCase
     doc = Hpricot('<input name="vendor[porkpies][meaty]"/>')
     assert_equal 1, (doc/'input[@name^="vendor[porkpies][meaty]"]').length
   end
+  # Colons should work according to:
+  # http://www.w3.org/TR/2000/REC-xml-20001006#NT-Name
+  def test_attr_double_colon
+    doc = Hpricot('<input name="parent:child:grandchild"/>')
+    assert_equal 1, (doc/'input[@name="parent:child:grandchild"]').length
+  end
+  # This is not a valid name attribute, but it shouldn't throw exceptions
+  def test_attr_exclamation_mark
+    doc = Hpricot('<input name="hello!"/>')
+    assert_equal 1, (doc/'input[@name="hello!"]').length
+  end
 end


### PR DESCRIPTION
There seems to be a problem with special characters (like :: and !) when used in selectors like:
input[@name="parent:child:grandchild"]

Fixed the following exception:
NoMethodError: undefined method `<<' for nil:NilClass
    ./lib/hpricot/elements.rb:307:in`filter'
    ./lib/hpricot/traverse.rb:327:in `/'
    ./test/test_paths.rb:29:in`test_attr_double_colon'

I'm not sure how to fix the remaining failing test where the element cannot be found by an attribute that has more than one colon...
