### PR TITLE
Unescape hex numeric character references

### DIFF
--- a/lib/hpricot/builder.rb
+++ b/lib/hpricot/builder.rb
@@ -8,7 +8,8 @@ module Hpricot
   def self.uxs(str)
     str.to_s.
         gsub(/\&(\w+);/) { [NamedCharacters[$1] || 63].pack("U*") }. # 63 = ?? (query char)
-        gsub(/\&\#(\d+);/) { [$1.to_i].pack("U*") }
+        gsub(/\&\#(\d+);/) { [$1.to_i].pack("U*") }.
+        gsub(/\&\#x([0-9a-fA-F]+);/) { [$1.to_i(16)].pack("U*") }
   end
 
   def self.build(ele = Doc.new, assigns = {}, &blk)

--- a/lib/hpricot/xchar.rb
+++ b/lib/hpricot/xchar.rb
@@ -87,7 +87,8 @@ module Hpricot
     def uxs(str)
       str.to_s.
           gsub(/\&\w+;/) { |x| (XChar::PREDEFINED_U[x] || 63).chr }. # 63 = ?? (query char)
-          gsub(/\&\#(\d+);/) { [$1.to_i].pack("U*") }
+          gsub(/\&\#(\d+);/) { [$1.to_i].pack("U*") }.
+          gsub(/\&\#x([0-9a-fA-F]+);/) { [$1.to_i(16)].pack("U*") }
     end
   end
 end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -417,6 +417,14 @@ class TestParser < Test::Unit::TestCase
     end
   end
 
+  def test_uxs_handles_hexadecimal_values
+    if String.method_defined? :encoding
+      assert_equal "é", Hpricot.uxs('&#xe9;')
+    else
+      assert_equal "\303\251", Hpricot.uxs('&#xe9;')
+    end
+  end
+
   def test_uxs_handles_entities
     if String.method_defined? :encoding
       assert_equal "é", Hpricot.uxs('&eacute;')


### PR DESCRIPTION
When I used Hpricot on XML containing hexadecimal character references – e.g. &amp;#x20; which is space – I noticed that they were not unescaped when for example retrieving attributes. So here is a little patch which unescapes them just in the same way as decimal character references are.

I modified xchar.rb too, even if it seems to be unused, just so they do not get out of sync.

– Andreas Karlsson
