### PR TITLE
Remove escaped quote

### DIFF
--- a/ext/hpricot_scan/hpricot_common.rl
+++ b/ext/hpricot_scan/hpricot_common.rl
@@ -16,9 +16,9 @@
 
   NameCap = Name >_tag %tag;
   NameAttr = NameChar+ >_akey %akey ;
-  Q1Char = ( "\\\'" | [^'] ) ;
+  Q1Char = [^'] ;
   Q1Attr = Q1Char* >_aval %aval ;
-  Q2Char = ( "\\\"" | [^"] ) ;
+  Q2Char = [^"] ;
   Q2Attr = Q2Char* >_aval %aval ;
   UnqAttr = ( space >_aval | [^ \t\r\n<>"'] >_aval [^ \t\r\n<>]* %aunq ) ; 
   Nmtoken = NameChar+ >_akey %akey ;

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -376,6 +376,14 @@ class TestParser < Test::Unit::TestCase
     assert_equal "button", doc.at("//form/input")['type']
   end
 
+  def test_escaped_quote
+    # Backslash '\' is not an escape character in HTML.
+    doc = Hpricot("<div><input type='text' value='C:\\dir\\' /><p id='test_id'>test</p></div>")
+    assert_equal "C:\\dir\\", doc.at("input")["value"]
+    doc = Hpricot('<div><input type="text" value="C:\\dir\\" /><p id="test_id">test</p></div>')
+    assert_equal "C:\\dir\\", doc.at("input")["value"]
+  end
+
   def test_filters
     @basic = Hpricot.parse(TestFiles::BASIC)
     assert_equal 0, (@basic/"title:parent").size


### PR DESCRIPTION
Hpricot seems to regard the backslash character as a special character which escapes a quotation,
though backslash character is a normal character in HTML document.

This patch ignores backslash.
For more detail, please refer to issue #50.

This is my first pull request. If this pull request is not convenient for you, please let me know.
