### PR TITLE
Fix 'undefined method `downcase' for nil:NilClass' on JRuby

### DIFF
--- a/ext/hpricot_scan/HpricotScanService.java
+++ b/ext/hpricot_scan/HpricotScanService.java
@@ -1281,7 +1281,7 @@ static final int hpricot_scan_en_main = 204;
 
                 pe = p + len;
 
-
+                
 // line 1286 "HpricotScanService.java"
 	{
 	int _klen;
@@ -1451,7 +1451,7 @@ case 3:
 	case 14:
 // line 553 "hpricot_scan.java.rl"
 	{
-      if(!S.xml) {
+      if(!S.xml && !akey.isNil()) {
           akey = akey.callMethod(runtime.getCurrentContext(), "downcase");
       }
       ATTR(akey, aval);

--- a/ext/hpricot_scan/hpricot_scan.java.rl
+++ b/ext/hpricot_scan/hpricot_scan.java.rl
@@ -551,7 +551,7 @@ public class HpricotScanService implements BasicLibraryService {
   }
 
   action save_attr {
-      if(!S.xml) {
+      if(!S.xml && !akey.isNil()) {
           akey = akey.callMethod(runtime.getCurrentContext(), "downcase");
       }
       ATTR(akey, aval);

--- a/test/files/bnqt.html
+++ b/test/files/bnqt.html
@@ -1,0 +1,1268 @@
+<!DOCTYPE html PUBLIC "-//W3C//Dtd XHTML 1.0 Transitional//EN" "http://www.w3.org/tr/xhtml1/Dtd/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>colinbane.bnqt.com -  - Skate life - 1</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<meta name="description" content="" />
+<meta name="keywords" content="P-Rod,Dayne Brummett,Mike Barnes,Ben Raybourn,Michael Brooke,Stu Graham,Pedro Barros,Cailin Lee,Dylan Perry,Nora Vasconcellos,Allen Danze,Glen E. Friedman,Nate LaCoste,Bones Brigade,Colby Carter,Rick Thorne,Paul Zitzer,Phil Hansen,Paul Cullen,Timeline Skateboards,Cordell Mansfield,FUEL.TV,Mark Appleyard,Austin Ayers,Dave Bachinsky," />
+<meta name="Revisit-after" content="1 Day" />
+<link rel="shortcut icon" href="http://colinbane.bnqt.com/public/frontend/assets/colinbane.bnqt.com/favicon.ico" type="image/x-icon"/>
+<link rel="icon" href="http://colinbane.bnqt.com/public/frontend/assets/colinbane.bnqt.com/favicon.ico" type="image/x-icon"/>
+<link href="http://colinbane.bnqt.com/public/frontend/assets/colinbane.bnqt.com/css/all.css" rel="stylesheet" type="text/css" />
+<link type="text/css" rel="stylesheet" href="/public/shared/js/lightview/css/lightview.css"/>
+<script src="/public/shared/js/scriptaculous/lib/prototype-git.js" type="text/javascript"></script>
+<script src="/public/shared/js/scriptaculous/src/scriptaculous.js" type="text/javascript"></script>
+<script src="/public/shared/js/swfobject.js" type="text/javascript"></script>
+<script type="text/javascript" src="/public/shared/js/flash.js"></script>
+<script type="text/javascript" src="/public/shared/js/horinaja.js"></script>
+<script type="text/javascript" src="/public/frontend/js/common.js"></script>
+<!------ OAS MJX Config Begins ------>
+<script type="text/javascript">
+<!--
+// Define OAS Variables
+OAS_url = 'http://oasc247.bnqt.com/RealMedia/ads/'; // Ad Server URL: 'oascentral.site.com'
+OAS_sitepage = 'colinebane-bnqt-com/index'; // Virtual URL, format (case sensitive) : 'www.site.com/section/subsection/page'
+OAS_listpos = 'Top,Middle,Middle1,Bottom,x01,x02'; // List of Positions on Page, format (case Sensitive) : 'Position1,Position2,Frame1,Frame2'
+OAS_query = ''; //Search Terms, format (case sensitive) : ‘KeyName1=KeyValue1&KeyName2=KeyValue2
+OAS_target = '_blank'; // Window parameter for clicks : (_top or _blank)
+//-->
+</script>
+<!------ OAS MJX Config Ends ------>
+
+<script type="text/javascript" src="http://colinbane.bnqt.com/public/frontend/js/video.js"></script><script type="text/javascript" src="http://colinbane.bnqt.com/public/shared/js/dropdown.js"></script><script type="text/javascript" src="http://colinbane.bnqt.com/public/frontend/js/main.js"></script><script type="text/javascript" src="http://colinbane.bnqt.com/public/frontend/js/blogs.js"></script><script type="text/javascript" src="http://colinbane.bnqt.com/public/frontend/js/blogExpander.js"></script><script type="text/javascript" src="http://colinbane.bnqt.com/public/frontend/js/photo_album.js"></script>
+<script type="text/javascript"> 
+videoSort.maxItem = 6; 
+videoSort.dateView = "all";
+videoSort.attribSort = "post_date";
+
+blogSort.maxItem = 6; 
+blogSort.dateView = "all";
+blogSort.attribSort = "post_date";
+
+albumSort.maxItem = 5; 
+albumSort.dateView = "all";
+albumSort.attribSort = "post_date";
+
+ctFeatured.Type = "";
+ctFeatured.attribSort = "post_date"; 
+ctFeatured.maxItem = 2;
+
+document.observe("dom:loaded", function() {  
+
+blogExpander.init();
+
+                    var HoriFeatured = new Horinaja("featuredContents",0.3,8,true,"featuredPaginationCtner","&bull;","indicatorSelected");
+					
+
+});
+</script>
+<!--// Google Analytics Start -->
+<script type="text/javascript">
+
+window._gaq = window._gaq || [];
+
+
+_gaq.push(
+    ['domainTracker1._setAccount', "UA-3632331-1"],
+    ['domainTracker1._trackPageview'],
+    ['domainTracker1._trackPageLoadTime']
+);
+
+_gaq.push(
+    ['domainTracker2._setAccount', "UA-3632331-21"],
+    ['domainTracker2._trackPageview'],
+    ['domainTracker2._trackPageLoadTime']
+);
+
+_gaq.push(
+    ['domainTracker3._setAccount', "UA-11570011-6"],
+    ['domainTracker3._trackPageview'],
+    ['domainTracker3._trackPageLoadTime']
+);
+</script>
+<!--// Google Analytics End -->
+
+
+<!--// BNQT Media Group Partner Toolbar Start -->
+<script type="text/javascript">
+            var _bTAccountId = 'colinbane.bnqt.com';
+            (function() {
+                            var _bjs = document.createElement('script');
+                            _bjs.async = true;
+                            _bjs.type = 'text/javascript';
+                            _bjs.src = 'http://img.bnqt.com/CMS/assets/toolbar/js/bnqtXToolbar.js';
+                            var _bss = document.getElementsByTagName('script')[0];
+                            _bss.parentNode.insertBefore(_bjs,_bss);
+            })();
+</script>
+<!--// BNQT Media Group Partner Toolbar End --> 
+</head><body>
+<div id="wrapper">
+        <div id="masthead">
+        <h2><a href="/" title="Home">BNQT Logo</a></h2>
+        <div class="ad" id="OAS_Top" style="position:static!important;"></div>
+        <div class="clearFloats"></div>
+        <div id="mainMenu">
+                <ul>
+    <li id="mmHome" class="selected"><a href="/" title="Home">Home</a></li>
+        <li id="mmVideos" ><a href="/videos/index.html" title="Videos">Videos</a></li>
+                <li id="mmBlogs" ><a href="/blogs/index.html" title="Blogs">Blogs</a></li>
+        <li id="search">
+        <form action="/search" method="post" id="theSearchForm">
+        <input type="hidden" name="searchIn[]" value="photo_albums">
+        <input type="hidden" name="searchIn[]" value="blogs">
+        <input type="hidden" name="searchIn[]" value="videos">
+        <table cellpadding="0" cellspacing="0">
+            <tr>
+                <td>
+					<div id="dummyContainer" style="position: relative">
+						<input name="searchField" id="searchField" type="text"  align="middle" value="Search..." onFocus="changeSearchBar(this); return false;" onBlur="changeSearchBar(this); return false;"/>
+						<div id="search_autoComplete" class="autocomplete"></div>
+						<script type="text/javascript">
+						new Ajax.Autocompleter('searchField', 'search_autoComplete', '/ajax/getTagsForSearch.html', {
+							paramName: 'search',
+							minChars: 1});
+						</script>
+					</div></td>
+                <td><a href="#" id="searchBtn" onClick="$('theSearchForm').submit();">Go</a></td>
+            </tr>
+        </table>
+        </form>
+    </li>
+</ul>        </div>
+        <!--/mainMenu-->
+        <div class="filterNav">
+                <ul>
+	
+    <li >&nbsp;COLINBANE.BNQT.COM: Skate life</li>
+</ul>
+<div class="clearFloats"></div>        </div>
+        <!--/filter-->
+     </div>
+    <!--/masthead-->
+	<div id="flashmenu"><!--// FLASH MESSAGE //-->
+<!--// FLASH MESSAGE //--></div><!--START INCLUDED CONTENT-->
+<div id="masterContainer" class="home">
+        <div class="leftPanel">
+          
+            <div class="box01 features">
+                <h1><span>Features</span><a href="/featured/all" title="archives"  class="floatRight">Archives</a></h1>
+                <div class="content">
+                	<div id="featuredContents" class="horinaja">
+                		<ul>
+        							<li>
+	
+								<table cellpadding="0" cellspacing="0" class="dataContent f00">
+									<tr>
+										<th>Blogs</th>
+									</tr>
+									<tr>
+										<td>
+											<a href="/blogs/detail/Ryan-Sheckler-one-on-one-against-Steve-Nash/5207">
+												<img src="http://img.bnqt.com/CMS/bnqt/network/colinbane.bnqt.com/media/colin-bane/0005-ae106a4f-4b2bec8f-bf4b-b0690b24_thumb.jpg" width="306" height="198" alt="Ryan Sheckler one-on-one against Steve Nash" />
+											</a>
+										</td>
+									</tr>
+									<tr>
+										<td class="padding5">
+											<p><a href="http://colinbane.bnqt.com/blogs/detail/Ryan-Sheckler-one-on-one-against-Steve-Nash/5207.html" class="title">RYAN SHECKLER ONE-ON-ONE AGAINST STEVE NASH</a></p>
+											<p class="defaultColor02">December 18, 2009</p>
+											<p>My brother-in-law sent over this clip I'd never seen before, of Ryan Sheckler popping an ollie over &#0133;   </p>
+											<p>by: <a href="http://colinbane.bnqt.com/user/Colin-Bane/5.html" title="Ryan Sheckler one-on-one against Steve Nash">Colin Bane</a></p>
+										</td>
+									</tr>
+								</table>
+	
+								<table cellpadding="0" cellspacing="0" class="dataContent f01">
+									<tr>
+										<th>Blogs</th>
+									</tr>
+									<tr>
+										<td>
+											<a href="/blogs/detail/Clich-Skateboards-Rsum-Euro-skate-history-textbook/5184">
+												<img src="http://img.bnqt.com/CMS/bnqt/network/colinbane.bnqt.com/media/colin-bane/0005-ae64eaf8-4b266171-09ea-f0b9efcc_thumb.jpg" width="306" height="198" alt="ClichÃƒÂ© Skateboards\' RÃƒÂ©sumÃƒÂ©: Euro skate history textbook" />
+											</a>
+										</td>
+									</tr>
+									<tr>
+										<td class="padding5">
+											<p><a href="http://colinbane.bnqt.com/blogs/detail/Clich-Skateboards-Rsum-Euro-skate-history-textbook/5184.html" class="title">CLICHÃƒÂ© SKATEBOARDS' RÃƒÂ©SUMÃƒÂ©: EURO S&#0133;</a></p>
+											<p class="defaultColor02">December 14, 2009</p>
+											<p>Clich
+
+'s new R
+
+sum
+
+ book is a 10-year anniversary project that took a couple extra years since Cl&#0133;   </p>
+											<p>by: <a href="http://colinbane.bnqt.com/user/Colin-Bane/5.html" title="ClichÃƒÂ© Skateboards\' RÃƒÂ©sumÃƒÂ©: Euro skate history textbook">Colin Bane</a></p>
+										</td>
+									</tr>
+								</table>
+								</li>	
+							<li>
+	
+								<table cellpadding="0" cellspacing="0" class="dataContent f00">
+									<tr>
+										<th>Blogs</th>
+									</tr>
+									<tr>
+										<td>
+											<a href="/blogs/detail/JP-Dantas-Anjinho-wins-DC-King-of-So-Paulo/5159">
+												<img src="http://img.bnqt.com/CMS/bnqt/network/colinbane.bnqt.com/media/colin-bane/0005-ae106f18-4b1fea11-4ca3-306997e9_thumb.jpg" width="306" height="198" alt="JP Dantas \"Anjinho\" wins DC King of SÃƒÂ£o Paulo" />
+											</a>
+										</td>
+									</tr>
+									<tr>
+										<td class="padding5">
+											<p><a href="http://colinbane.bnqt.com/blogs/detail/JP-Dantas-Anjinho-wins-DC-King-of-So-Paulo/5159.html" class="title">JP DANTAS "ANJINHO" WINS DC KING OF SÃƒÂ£O PAULO</a></p>
+											<p class="defaultColor02">December 09, 2009</p>
+											<p>The Brazilian skate dudes are taking over the whole damned world, so DC Shoes took its King Of... co&#0133;   </p>
+											<p>by: <a href="http://colinbane.bnqt.com/user/Colin-Bane/5.html" title="JP Dantas \"Anjinho\" wins DC King of SÃƒÂ£o Paulo">Colin Bane</a></p>
+										</td>
+									</tr>
+								</table>
+	
+								<table cellpadding="0" cellspacing="0" class="dataContent f01">
+									<tr>
+										<th>Blogs</th>
+									</tr>
+									<tr>
+										<td>
+											<a href="/blogs/detail/eBay-Watch-The-recession-is-over-Hosoi-deck-sells-for-5g/5094">
+												<img src="http://img.bnqt.com/CMS/bnqt/network/colinbane.bnqt.com/media/colin-bane/0005-3fe17f2e-4b0c5b5c-749a-f0d24a99_thumb.jpg" width="306" height="198" alt="eBay Watch: The recession is over, Hosoi deck sells for $5g" />
+											</a>
+										</td>
+									</tr>
+									<tr>
+										<td class="padding5">
+											<p><a href="http://colinbane.bnqt.com/blogs/detail/eBay-Watch-The-recession-is-over-Hosoi-deck-sells-for-5g/5094.html" class="title">EBAY WATCH: THE RECESSION IS OVER, HOSOI DECK SELLS FOR&#0133;</a></p>
+											<p class="defaultColor02">November 24, 2009</p>
+											<p>Yeah, yeah, I know: I link to Skate And Annoy's eBay Watch column just about every month. i continue&#0133;   </p>
+											<p>by: <a href="http://colinbane.bnqt.com/user/Colin-Bane/5.html" title="eBay Watch: The recession is over, Hosoi deck sells for $5g">Colin Bane</a></p>
+										</td>
+									</tr>
+								</table>
+								</li>	
+							<li>
+	
+								<table cellpadding="0" cellspacing="0" class="dataContent f00">
+									<tr>
+										<th>Blogs</th>
+									</tr>
+									<tr>
+										<td>
+											<a href="/blogs/detail/Chris-Cole-wins-Battle-at-the-Berrics-2/5089">
+												<img src="http://img.bnqt.com/CMS/bnqt/network/colinbane.bnqt.com/media/colin-bane/0005-3fe17f2e-4b0b0f30-1fb4-1e0920e0_thumb.jpg" width="306" height="198" alt="Chris Cole wins Battle at the Berrics 2" />
+											</a>
+										</td>
+									</tr>
+									<tr>
+										<td class="padding5">
+											<p><a href="http://colinbane.bnqt.com/blogs/detail/Chris-Cole-wins-Battle-at-the-Berrics-2/5089.html" class="title">CHRIS COLE WINS BATTLE AT THE BERRICS 2</a></p>
+											<p class="defaultColor02">November 23, 2009</p>
+											<p>Chris Cole won $10,000 at Battle at the Berrics 2, beating out Paul Rodriguez in the Finals bracket.&#0133;   </p>
+											<p>by: <a href="http://colinbane.bnqt.com/user/Colin-Bane/5.html" title="Chris Cole wins Battle at the Berrics 2">Colin Bane</a></p>
+										</td>
+									</tr>
+								</table>
+	
+								<table cellpadding="0" cellspacing="0" class="dataContent f01">
+									<tr>
+										<th>Blogs</th>
+									</tr>
+									<tr>
+										<td>
+											<a href="/blogs/detail/Lyn-Z-Adams-Hawkins-First-female-skater-to-land-McTwist/5082">
+												<img src="http://img.bnqt.com/CMS/bnqt/network/colinbane.bnqt.com/media/colin-bane/0005-3fe17f2e-4b0abad2-54db-2137b2ac_thumb.jpg" width="306" height="198" alt="Lyn-Z Adams-Hawkins: First female skater to land McTwist" />
+											</a>
+										</td>
+									</tr>
+									<tr>
+										<td class="padding5">
+											<p><a href="http://colinbane.bnqt.com/blogs/detail/Lyn-Z-Adams-Hawkins-First-female-skater-to-land-McTwist/5082.html" class="title">LYN-Z ADAMS-HAWKINS: FIRST FEMALE SKATER TO LAND MCTWIS&#0133;</a></p>
+											<p class="defaultColor02">November 23, 2009</p>
+											<p>Sick video from The Tony Hawk Show this weekend at the Gran Palais in Paris: Watch through to the 1:&#0133;   </p>
+											<p>by: <a href="http://colinbane.bnqt.com/user/Colin-Bane/5.html" title="Lyn-Z Adams-Hawkins: First female skater to land McTwist">Colin Bane</a></p>
+										</td>
+									</tr>
+								</table>
+								</li>	
+							<li>
+	
+								<table cellpadding="0" cellspacing="0" class="dataContent f00">
+									<tr>
+										<th>Blogs</th>
+									</tr>
+									<tr>
+										<td>
+											<a href="/blogs/detail/Stephen-Colbert-skateboards-with-Congresswoman-Jackie-Speier-Reps-McGovern-Kennedy/5056">
+												<img src="http://img.bnqt.com/CMS/bnqt/network/colinbane.bnqt.com/media/colin-bane/0005-3fe17f2e-4b0498d3-ae51-e9381ac1_thumb.jpg" width="306" height="198" alt="Stephen Colbert skateboards with Congresswoman Jackie Speier, Reps McGovern & Kennedy" />
+											</a>
+										</td>
+									</tr>
+									<tr>
+										<td class="padding5">
+											<p><a href="http://colinbane.bnqt.com/blogs/detail/Stephen-Colbert-skateboards-with-Congresswoman-Jackie-Speier-Reps-McGovern-Kennedy/5056.html" class="title">STEPHEN COLBERT SKATEBOARDS WITH CONGRESSWOMAN JACKIE S&#0133;</a></p>
+											<p class="defaultColor02">November 18, 2009</p>
+											<p>The Colbert Report earns its way onto this skate blog this week with its "Better Know a District" se&#0133;   </p>
+											<p>by: <a href="http://colinbane.bnqt.com/user/Colin-Bane/5.html" title="Stephen Colbert skateboards with Congresswoman Jackie Speier, Reps McGovern & Kennedy">Colin Bane</a></p>
+										</td>
+									</tr>
+								</table>
+	
+								<table cellpadding="0" cellspacing="0" class="dataContent f01">
+									<tr>
+										<th>Blogs</th>
+									</tr>
+									<tr>
+										<td>
+											<a href="/blogs/detail/SF-Skateboarding-Association-benefit-tonight-1115/5044">
+												<img src="http://img.bnqt.com/CMS/bnqt/network/colinbane.bnqt.com/media/colin-bane/0005-3fe17f2e-4b001541-e558-96bf729e_thumb.jpg" width="306" height="198" alt="SF Skateboarding Association benefit tonight 11/15" />
+											</a>
+										</td>
+									</tr>
+									<tr>
+										<td class="padding5">
+											<p><a href="http://colinbane.bnqt.com/blogs/detail/SF-Skateboarding-Association-benefit-tonight-1115/5044.html" class="title">SF SKATEBOARDING ASSOCIATION BENEFIT TONIGHT 11/15</a></p>
+											<p class="defaultColor02">November 15, 2009</p>
+											<p>Heads up, San Francisco: The SFSA is having a big benefit event tonight at 111 Minna Art Gallery to &#0133;   </p>
+											<p>by: <a href="http://colinbane.bnqt.com/user/Colin-Bane/5.html" title="SF Skateboarding Association benefit tonight 11/15">Colin Bane</a></p>
+										</td>
+									</tr>
+								</table>
+								</li>	
+							<li>
+	
+								<table cellpadding="0" cellspacing="0" class="dataContent f00">
+									<tr>
+										<th>Blogs</th>
+									</tr>
+									<tr>
+										<td>
+											<a href="/blogs/detail/Voting-open-now-for-Thrasher-Skater-Of-The-Year-2009/5036">
+												<img src="http://img.bnqt.com/CMS/bnqt/network/colinbane.bnqt.com/media/colin-bane/0005-d8a08c64-4afda08f-76fd-72cf6454_thumb.jpg" width="306" height="198" alt="Voting open now for Thrasher Skater Of The Year 2009" />
+											</a>
+										</td>
+									</tr>
+									<tr>
+										<td class="padding5">
+											<p><a href="http://colinbane.bnqt.com/blogs/detail/Voting-open-now-for-Thrasher-Skater-Of-The-Year-2009/5036.html" class="title">VOTING OPEN NOW FOR THRASHER SKATER OF THE YEAR 2009</a></p>
+											<p class="defaultColor02">November 13, 2009</p>
+											<p>Yep, it's that time of year again: Get on over to ThrasherMagazine.com to check out their new SOTY p&#0133;   </p>
+											<p>by: <a href="http://colinbane.bnqt.com/user/Colin-Bane/5.html" title="Voting open now for Thrasher Skater Of The Year 2009">Colin Bane</a></p>
+										</td>
+									</tr>
+								</table>
+	
+								<table cellpadding="0" cellspacing="0" class="dataContent f01">
+									<tr>
+										<th>Blogs</th>
+									</tr>
+									<tr>
+										<td>
+											<a href="/blogs/detail/UPDATE-Steve-Rodriguez-on-the-sketchy-future-for-Brooklyn-Banks/5025">
+												<img src="http://img.bnqt.com/CMS/bnqt/network/colinbane.bnqt.com/media/colin-bane/0005-d8a08c64-4afb2e23-d79f-12d3449c_thumb.jpg" width="306" height="198" alt="UPDATE: Steve Rodriguez on the sketchy future for Brooklyn Banks" />
+											</a>
+										</td>
+									</tr>
+									<tr>
+										<td class="padding5">
+											<p><a href="http://colinbane.bnqt.com/blogs/detail/UPDATE-Steve-Rodriguez-on-the-sketchy-future-for-Brooklyn-Banks/5025.html" class="title">UPDATE: STEVE RODRIGUEZ ON THE SKETCHY FUTURE FOR BROOK&#0133;</a></p>
+											<p class="defaultColor02">November 11, 2009</p>
+											<p>As we've previously reported, it looks like the legendary skate spot Brooklyn Banks is at least temp&#0133;   </p>
+											<p>by: <a href="http://colinbane.bnqt.com/user/Colin-Bane/5.html" title="UPDATE: Steve Rodriguez on the sketchy future for Brooklyn Banks">Colin Bane</a></p>
+										</td>
+									</tr>
+								</table>
+								</li>	
+						
+						</ul>	
+					</div>
+					<div class="clearFloats"></div>
+                </div>
+                <!--/.content-->
+				<div class="indicatorsContainer">
+				    <div id="featuredPaginationCtner" class="indicator">
+										    </div>
+				    <!--/.indicators-->     
+					<div class="clearFloats"></div>                
+				</div>
+				<!--/.indicatorsContainer-->
+
+            </div>
+            <!--/.box01 features-->
+
+
+            
+
+<div class="box01 blogPost">
+	<h3>November 20, 2009 &raquo; <span class="uppercase">Blogs</span></h3>
+    <h4><a href="http://colinbane.bnqt.com/blogs/detail/Skate-and-Annoy-is-back-at-it-pass-the-word/5067.html" title="Skate and Annoy is back at it, pass the word" class="title">Skate and Annoy is back at it, pass the word</a><br />
+		<span>by: <a href="http://colinbane.bnqt.com/user/Colin Bane/5.html" title="Skate and Annoy is back at it, pass the word">Colin Bane</a></span></h4>
+    <div class="content">
+        <div class="blogBody">
+            <p><span class="blogImg alignleft"><a href="http://img.bnqt.com/CMS/bnqt/network/colinbane.bnqt.com/media/colin-bane/0005-3fe17f2e-4b071a41-4335-ea08152d.jpg" class="lightview" rel="gallery[Skate and Annoy is back at it, pass the word]" title=""><img style="float: left; margin: 5px;" src="http://img.bnqt.com/CMS/bnqt/network/colinbane.bnqt.com/media/colin-bane/0005-3fe17f2e-4b071a41-4335-ea08152d_thumb.jpg" id="media_15627" mediaimage="15627" height="180" width="300" /></a><span class="blogImgDesc defaultLinkColor03 defaultColor02"></span></span>Spread the word: One of my favorite sites, <a target="_blank" href="http://skateandannoy.com/2009/11/fickle/">Skate And Annoy, is annoying again</a>.</p>
+<p>Here's a quick note from the editor, Kilwag:</p>
+<p>After a really rocky month and many false starts, Skate and Annoy has been back up for over a week now. It seems like we
+
+
+ve lost about 40 -50% of our traffic, but the trend is creeping upward. Do me a favor and spread the word that we
+
+
+re here, (we
+
+
+re queer- or mongo? goofy?) get used to it.</p>        </div>
+	    <div class="clearFloats"></div>
+
+    </div>
+    <!--/.content-->
+</div>
+		
+<div class="box01 blogPost">
+	<h3>November 11, 2009 &raquo; <span class="uppercase">Blogs</span></h3>
+    <h4><a href="http://colinbane.bnqt.com/blogs/detail/Tony-Hawk-coolest-guy-ever-to-wear-a-dorky-helmet-on-NPR-Not-My-Job/5024.html" title="Tony Hawk, \'coolest guy ever to wear a dorky helmet,\' on NPR \'Not My Job\'" class="title">Tony Hawk, 'coolest guy ever to wear a dorky helmet,' on NPR 'Not My Job'</a><br />
+		<span>by: <a href="http://colinbane.bnqt.com/user/Colin Bane/5.html" title="Tony Hawk, \'coolest guy ever to wear a dorky helmet,\' on NPR \'Not My Job\'">Colin Bane</a></span></h4>
+    <div class="content">
+        <div class="blogBody">
+            <p><span class="blogImg alignleft"><a href="http://img.bnqt.com/CMS/bnqt/network/colinbane.bnqt.com/media/colin-bane/0005-d8a08c64-4afb1d8b-806a-2dcf904c.jpg" class="lightview" rel="gallery[Tony Hawk, &amp;apos;coolest guy ever to wear a dorky helmet,&amp;apos; on NPR &amp;apos;Not My Job&amp;apos;]" title=""><img style="float: left; margin: 5px;" src="http://img.bnqt.com/CMS/bnqt/network/colinbane.bnqt.com/media/colin-bane/0005-d8a08c64-4afb1d8b-806a-2dcf904c_thumb.jpg" id="media_15523" mediaimage="15523" height="180" width="300" /></a><span class="blogImgDesc defaultLinkColor03 defaultColor02"></span></span><a target="_blank" href="http://www.npr.org/templates/story/story.php?storyId=120167628&sc=emaf">Tony Hawk was on NPR's "Not My Job" </a>show this week, answering some ridiculous "Hey! You could put an eye out!" questions about safety measures not at all related to skateboarding. He also takes on the stock "I've been dying to ask this question: How many broken bones have you had in your lifetime?" question from one of the show's hosts, talks about his legacy of Madonnas and Sean Penns, and mentions the trumpedup pundit outrage after he skateboarded in the White House.</p>
+<p>"What did they expect you to do, walk?"</p>
+<p>Tony Hawk on NPR? Dude's everywhere. As long as it ultimately <a target="_blank" href="http://tonyhawkfoundation.org/">helps get more killer concrete skateparks put up all over the damned place</a>, I'm cool with it.</p>
+<p>Have a listen:</p>
+<p>
+<object width="400" height="386" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,0,40,0">
+
+
+<embed src="http://www.npr.org/v2/?i=120167628&m=120196850&t=audio" type="application/x-shockwave-flash" width="400" height="386" wmode="opaque" allowfullscreen="true"></embed>
+</object>
+</p>        </div>
+	    <div class="clearFloats"></div>
+
+    </div>
+    <!--/.content-->
+</div>
+		
+<div class="box01 blogPost">
+	<h3>November 10, 2009 &raquo; <span class="uppercase">Blogs</span></h3>
+    <h4><a href="http://colinbane.bnqt.com/blogs/detail/Skateboard-Evolution-Art-in-California-opens-1114-California-Heritage-Museum/5017.html" title="Skateboard Evolution & Art in California opens 11/14, California Heritage Museum" class="title">Skateboard Evolution & Art in California opens 11/14, California Heritage Museum</a><br />
+		<span>by: <a href="http://colinbane.bnqt.com/user/Colin Bane/5.html" title="Skateboard Evolution & Art in California opens 11/14, California Heritage Museum">Colin Bane</a></span></h4>
+    <div class="content">
+        <div class="blogBody">
+            <p><img style="float: left; margin: 5px;" src="http://web.mac.com/calmuseum/Site/Upcoming_files/Picture 1.jpg" height="395" width="284" />Skateboard art is getting big props for its role in California culture this weekend: The California Heritage Museum in Santa Monica opens its new Skateboard Evolution & Art exhibit on Saturday.</p>
+<p>Here's the full press release <a target="_blank" href="http://web.mac.com/calmuseum/Site/Upcoming.html">via California Heritage Museum</a>:</p>
+<p style="padding: 0px;">
+
+</p>
+<p style="padding-top: 0pt;"><span style="line-height: 15px;">The California Heritage Museum is proud to present 
+
+
+SKATEBOARD: Evolution and Art in California.
+
+
+ The show opens to the general public on Saturday, November 14, 2009 and continues through Sunday, May 30, 2010. <br /></span></p>
+<p><span style="line-height: 15px;">Guest curated by legendary Z-boy Nathan Pratt in conjunction with museum staff curator Michael Trotter and advisory committee members Jeff Ho, Skip Engblom (Zephyr co-founders), Cris Dawson (1966 Hobie Champ), Z-Boys Tony Alva and Stacy Peralta, and 1980
+
+
+s world champion Christian Hosoi, the exhibition traces the evolution of boards from pre-1950 to the present showcasing the riders, designers, artists, and manufacturers that created the California phenomenon known as the skateboard. From the first planks of wood with metal roller skate wheels nailed to the bottom to the modern polyurethane wheels and kicktails, the boards have rocketed the skaters to greater heights of performance and style while taking 
+
+
+sidewalk surfing
+
+
+ from a homegrown activity to a worldwide cultural phenomenon.<br /></span></p>
+<p><span style="line-height: 15px;">More than 275 rare boards from the world
+
+
+s finest collections including</span><span style="line-height: 15px;" xml:lang="--multilingual" lang="--multilingual"> Jason Cohn, Dale Smith/Skate Designs Inc., Todd Huber/Skatelab Skatepark, Ray Flores, James Lang/South Bay Skates.<br /></span></p>
+<p><span style="line-height: 15px;" xml:lang="--multilingual" lang="--multilingual">Additional lenders included are Kevin Anderson/Model Worm, Art Brewer, Terry Campion, Cris Dawson, Deluxe Distribution, Earl, Skip Engblom, Craig Fineman, Wayne and Donna Gunter/Surfing Cowboys, Mike Horelick/Tunnel Skateboards,
+
+ Chuck Katx, Mike Kolar, Gordon McClelland, Jim McDowell/RIPWynn City Skates, Marc McKee, Aaron
+
+ Murray, James O
+
+
+Mahoney/Santa Barbara Surfing Museum, Nathan Pratt, Mark Richards/Val Surf, Ronnie/Animal House, Steve Salyer/Pastures of Heaven, Gabriel Steptoe, Joel Tudor, Wentzle Ruml IV, Cary B. Weiss, Z-BOY Archive, and Z-CULT Skates</span><span style="line-height: 15px;">. Photographs and art by C.R. Stecyk III, Glen E. Friedman,
+
+ Craig Fineman,
+
+ Wynn Miller, Kevin Ancell, Wes Humpston and more document the movement and its personalities. <br /></span></p>
+<p><span style="line-height: 15px;">This is the first exhibition of the California skate movement to be shown in 
+
+
+Dog Town
+
+
+, the Santa Monica/Ocean Park area where modern skateboarding was born and the skate became an art form. The California Heritage Museum is located in the vortex at Main Street and Ocean Park Boulevard.
+
+ <br /></span></p>
+<p style="padding-bottom: 0pt;"><span style="line-height: 15px;">A full series of events, including film screenings of </span><span style="line-height: 15px;">Dogtown and Z-Boys</span><span style="line-height: 15px;">, </span><span style="line-height: 15px;">Skater Dater</span><span style="line-height: 15px;"> and </span><span style="line-height: 15px;">Rising Son: The Christian Hosoi Story</span><span style="line-height: 15px;">, will take place at the museum and the downtown Santa Monica Library. Talks, photo exhibits, special guest appearances and autograph sessions will take place throughout the exhibit run into 2010.</span></p>
+<p style="padding: 0px;">
+
+</p>
+<p style="padding-top: 0pt; line-height: 21.185px;"><span style="line-height: 21.185px;">Opening November 14, 2009<br /></span></p>        </div>
+	    <div class="clearFloats"></div>
+
+    </div>
+    <!--/.content-->
+</div>
+		
+<div class="box01 blogPost">
+	<h3>November 03, 2009 &raquo; <span class="uppercase">Blogs</span></h3>
+    <h4><a href="http://colinbane.bnqt.com/blogs/detail/Etnies-pimps-out-a-Casa-Surf-suite-at-La-Casa-del-Camino/5000.html" title="Etnies pimps out a Casa Surf suite at La Casa del Camino" class="title">Etnies pimps out a Casa Surf suite at La Casa del Camino</a><br />
+		<span>by: <a href="http://colinbane.bnqt.com/user/Colin Bane/5.html" title="Etnies pimps out a Casa Surf suite at La Casa del Camino">Colin Bane</a></span></h4>
+    <div class="content">
+        <div class="blogBody">
+            <p>My FUEL.TV colleague Carlton Curtis is up today with a sweet slideshow from the new Casa Surf project at La Casa del Camino in Laguna Beach, CA, including this shot from the Etnies Suite.</p>
+<p><a target="_blank" href="http://www.fuel.tv/carletoncurtis/blogs/view/76734">Via FUEL.TV</a>:</p>
+<p>Talk about "extreme" makeovers. Orange County's Riviera Magazine invited ten SoCal surf-and-skate brands to imagine what their dream room would look like   the results of which can now be found at the Riviera Design Series' "Casa Surf Project". It's a novel concept, really: Brands like Quiksilver, Billabong, and Etnies have already conquered the apparel game, so why not spruce up the place where we end up after a day of ripping? Home sweet home. </p>
+<p><img src="http://ss.servers.fuel.tv/ugc/carletoncurtis/pictures/UF_44327/preview_url_max_540_IMG_4136_JPG.jpg" style="margin: 5px;" height="360" width="540" /></p>        </div>
+	    <div class="clearFloats"></div>
+
+    </div>
+    <!--/.content-->
+</div>
+		
+<div class="box01 blogPost">
+	<h3>October 28, 2009 &raquo; <span class="uppercase">Blogs</span></h3>
+    <h4><a href="http://colinbane.bnqt.com/blogs/detail/Chaz-Ortiz-Officially-Down-with-ZY/4980.html" title="Chaz Ortiz: \'Officially Down\' with ZY" class="title">Chaz Ortiz: 'Officially Down' with ZY</a><br />
+		<span>by: <a href="http://colinbane.bnqt.com/user/Colin Bane/5.html" title="Chaz Ortiz: \'Officially Down\' with ZY">Colin Bane</a></span></h4>
+    <div class="content">
+        <div class="blogBody">
+            <p><img style="float: left; margin: 5px;" src="http://www.zooyork.com/blog/wp-content/uploads/2009/10/thrasher-ad.jpg" height="353" width="547" />Looks like Zoo York is giving up the game of pretending Chaz Ortiz isn't a pro, after winning the 2008 Dew Tour and little events like the... uh... PlayStation Pro, and then holding his own for another year of pro competition all over the place in 2009.</p>
+<p>Peep this new ZY ad: <a target="_blank" href="http://www.zooyork.com/blog/officially-down-ad-2-chaz-ortiz/">Chaz Ortiz is Officially Down</a>.</p>        </div>
+	    <div class="clearFloats"></div>
+
+    </div>
+    <!--/.content-->
+</div>
+		
+
+    <div class="clearFloats"></div>
+    <div class="pagination floatRight">
+        1<a href="http://colinbane.bnqt.com/post_date/5">2</a><a href="http://colinbane.bnqt.com/post_date/10">3</a><a href="http://colinbane.bnqt.com/post_date/5">&gt</a><a href="http://colinbane.bnqt.com/post_date/455">Last &rsaquo;</a>    </div>
+    <div class="clearFloats"></div>
+ 
+    <!--/.content-->
+
+
+ 
+
+
+        </div>
+        <!--/.leftPanel-->    	
+        
+        
+        
+        <div class="rightPanel">
+<div class="box01 recentComments">
+    <h1 class="defaultColor02"><span>Recent Comments</span></h1>
+    <div class="content">
+            <table cellpadding="0" cellspacing="0" class="dataContent">
+        <col width="39" />
+        <col width="*" />
+            <tr>
+                <td><a href="/blogs/detail/Chaz-Ortiz-Officially-Down-with-ZY/4980"><img src="http://img.bnqt.com/CMS/bnqt/network/colinbane.bnqt.com/media/colin-bane/0005-ae64eaf8-4ae87329-2a77-eeb08839_thumb.jpg" width="39" alt="Chaz Ortiz: \'Officially Down\' with ZY"/></td>
+                <td class="defaultColor02">
+                        <p>By: hammers young</p>
+                    <p>On: 
+					<div style="border:1px solid #990000;padding-left:20px;margin:0 0 10px 0;">
+
+<h4>A PHP Error was encountered</h4>
+
+<p>Severity: Notice</p>
+<p>Message:  Undefined index: HTTP_USER_AGENT</p>
+<p>Filename: template/container.php(14) : eval()'d code</p>
+<p>Line Number: 27</p>
+
+</div><a href="http://colinbane.bnqt.com/blogs/detail/Chaz-Ortiz-Officially-Down-with-ZY/4980.html" title="title">Chaz Ortiz: 'Officially Down' with</a>&#0133;                    </p>
+                </td>
+            </tr>
+        </table>
+         <table cellpadding="0" cellspacing="0" class="dataContent">
+        <col width="39" />
+        <col width="*" />
+            <tr>
+                <td><a href="/blogs/detail/Axel-Cruysberghs-Wins-2009-European-Skateboard-Championships/610"><img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/colin-bane/0005-4ca7ffb1-4a827ae3-ea27-5baeb804_thumb.jpg" width="39" alt="Axel Cruysberghs Wins 2009 European Skateboard Championships"/></td>
+                <td class="defaultColor02">
+                        <p>By: cici</p>
+                    <p>On: 
+					<div style="border:1px solid #990000;padding-left:20px;margin:0 0 10px 0;">
+
+<h4>A PHP Error was encountered</h4>
+
+<p>Severity: Notice</p>
+<p>Message:  Undefined index: HTTP_USER_AGENT</p>
+<p>Filename: template/container.php(14) : eval()'d code</p>
+<p>Line Number: 27</p>
+
+</div><a href="http://colinbane.bnqt.com/blogs/detail/Axel-Cruysberghs-Wins-2009-European-Skateboard-Championships/610.html" title="title">Axel Cruysberghs Wins 2009 Europea</a>&#0133;                    </p>
+                </td>
+            </tr>
+        </table>
+         <table cellpadding="0" cellspacing="0" class="dataContent">
+        <col width="39" />
+        <col width="*" />
+            <tr>
+                <td><a href="/blogs/detail/Mukee-Design-Recycled-Skateboard-Jewelry/601"><img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/colin-bane/0005-4ca7ffb1-4a827acb-1b67-3fa4749b_thumb.jpg" width="39" alt="Mukee Design: Recycled Skateboard Jewelry"/></td>
+                <td class="defaultColor02">
+                        <p>By: Chris</p>
+                    <p>On: 
+					<div style="border:1px solid #990000;padding-left:20px;margin:0 0 10px 0;">
+
+<h4>A PHP Error was encountered</h4>
+
+<p>Severity: Notice</p>
+<p>Message:  Undefined index: HTTP_USER_AGENT</p>
+<p>Filename: template/container.php(14) : eval()'d code</p>
+<p>Line Number: 27</p>
+
+</div><a href="http://colinbane.bnqt.com/blogs/detail/Mukee-Design-Recycled-Skateboard-Jewelry/601.html" title="title">Mukee Design: Recycled Skateboard </a>&#0133;                    </p>
+                </td>
+            </tr>
+        </table>
+         <table cellpadding="0" cellspacing="0" class="dataContent">
+        <col width="39" />
+        <col width="*" />
+            <tr>
+                <td><a href="/blogs/detail/Dew-Tour-Debuts-Womens-Comp-at-ISF-Skate-Open-Ladies-Lineup-Announced/589"><img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/colin-bane/0005-4ca7ffb1-4a827aad-8b87-661716da_thumb.jpg" width="39" alt="Dew Tour Debuts Women\'s Comp at ISF Skate Open; Ladies\' Lineup Announced"/></td>
+                <td class="defaultColor02">
+                        <p>By: cheap-prada.com</p>
+                    <p>On: 
+					<div style="border:1px solid #990000;padding-left:20px;margin:0 0 10px 0;">
+
+<h4>A PHP Error was encountered</h4>
+
+<p>Severity: Notice</p>
+<p>Message:  Undefined index: HTTP_USER_AGENT</p>
+<p>Filename: template/container.php(14) : eval()'d code</p>
+<p>Line Number: 27</p>
+
+</div><a href="http://colinbane.bnqt.com/blogs/detail/Dew-Tour-Debuts-Womens-Comp-at-ISF-Skate-Open-Ladies-Lineup-Announced/589.html" title="title">Dew Tour Debuts Women's Comp at IS</a>&#0133;                    </p>
+                </td>
+            </tr>
+        </table>
+         <table cellpadding="0" cellspacing="0" class="dataContent">
+        <col width="39" />
+        <col width="*" />
+            <tr>
+                <td><a href="/blogs/detail/Sneak-Peek-National-Museum-of-American-Indian-Ramp-It-Up-Skateboard-Culture-in-Native-America/552"><img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/colin-bane/0005-4ca7ffb1-4a827a3d-46e2-36f20c5a_thumb.jpg" width="39" alt="Sneak Peek: National Museum of American Indian \'Ramp It Up: Skateboard Culture in Native America\'"/></td>
+                <td class="defaultColor02">
+                        <p>By: nativeskatepark</p>
+                    <p>On: 
+					<div style="border:1px solid #990000;padding-left:20px;margin:0 0 10px 0;">
+
+<h4>A PHP Error was encountered</h4>
+
+<p>Severity: Notice</p>
+<p>Message:  Undefined index: HTTP_USER_AGENT</p>
+<p>Filename: template/container.php(14) : eval()'d code</p>
+<p>Line Number: 27</p>
+
+</div><a href="http://colinbane.bnqt.com/blogs/detail/Sneak-Peek-National-Museum-of-American-Indian-Ramp-It-Up-Skateboard-Culture-in-Native-America/552.html" title="title">Sneak Peek: National Museum of Ame</a>&#0133;                    </p>
+                </td>
+            </tr>
+        </table>
+         <table cellpadding="0" cellspacing="0" class="dataContent">
+        <col width="39" />
+        <col width="*" />
+            <tr>
+                <td><a href="/blogs/detail/Sneak-Peek-National-Museum-of-American-Indian-Ramp-It-Up-Skateboard-Culture-in-Native-America/552"><img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/colin-bane/0005-4ca7ffb1-4a827a3d-46e2-36f20c5a_thumb.jpg" width="39" alt="Sneak Peek: National Museum of American Indian \'Ramp It Up: Skateboard Culture in Native America\'"/></td>
+                <td class="defaultColor02">
+                        <p>By: nativeskatepark</p>
+                    <p>On: 
+					<div style="border:1px solid #990000;padding-left:20px;margin:0 0 10px 0;">
+
+<h4>A PHP Error was encountered</h4>
+
+<p>Severity: Notice</p>
+<p>Message:  Undefined index: HTTP_USER_AGENT</p>
+<p>Filename: template/container.php(14) : eval()'d code</p>
+<p>Line Number: 27</p>
+
+</div><a href="http://colinbane.bnqt.com/blogs/detail/Sneak-Peek-National-Museum-of-American-Indian-Ramp-It-Up-Skateboard-Culture-in-Native-America/552.html" title="title">Sneak Peek: National Museum of Ame</a>&#0133;                    </p>
+                </td>
+            </tr>
+        </table>
+     <div class="clearFloats"></div>
+    </div>
+    <!--/.content-->
+</div>
+<!--/.box01 recentlyAdded--> 
+<div class="ad02"  id="OAS_Middle">
+
+</div> 
+
+<div class="box01 tags">
+	<h1 class="defaultColor02"><span>Tags</span></h1>
+    <div class="content">
+    <p> 		<a href="/search/blogs/P-Rod"><span style="font-size: 13px !important;">P-Rod</span></a>
+ 		<a href="/search/blogs/Dayne-Brummett"><span style="font-size: 11px !important;">Dayne Brummett</span></a>
+ 		<a href="/search/blogs/Mike-Barnes"><span style="font-size: 11px !important;">Mike Barnes</span></a>
+ 		<a href="/search/blogs/Ben-Raybourn"><span style="font-size: 11px !important;">Ben Raybourn</span></a>
+ 		<a href="/search/blogs/Michael-Brooke"><span style="font-size: 11px !important;">Michael Brooke</span></a>
+ 		<a href="/search/blogs/Stu-Graham"><span style="font-size: 11px !important;">Stu Graham</span></a>
+ 		<a href="/search/blogs/Pedro-Barros"><span style="font-size: 11px !important;">Pedro Barros</span></a>
+ 		<a href="/search/blogs/Cailin-Lee"><span style="font-size: 11px !important;">Cailin Lee</span></a>
+ 		<a href="/search/blogs/Dylan-Perry"><span style="font-size: 11px !important;">Dylan Perry</span></a>
+ 		<a href="/search/blogs/Nora-Vasconcellos"><span style="font-size: 11px !important;">Nora Vasconcellos</span></a>
+ 		<a href="/search/blogs/Allen-Danze"><span style="font-size: 11px !important;">Allen Danze</span></a>
+ 		<a href="/search/blogs/Glen-E.-Friedman"><span style="font-size: 11px !important;">Glen E. Friedman</span></a>
+ 		<a href="/search/blogs/Nate-LaCoste"><span style="font-size: 11px !important;">Nate LaCoste</span></a>
+ 		<a href="/search/blogs/Bones-Brigade"><span style="font-size: 11px !important;">Bones Brigade</span></a>
+ 		<a href="/search/blogs/Colby-Carter"><span style="font-size: 11px !important;">Colby Carter</span></a>
+ 		<a href="/search/blogs/Rick-Thorne"><span style="font-size: 11px !important;">Rick Thorne</span></a>
+ 		<a href="/search/blogs/Paul-Zitzer"><span style="font-size: 11px !important;">Paul Zitzer</span></a>
+ 		<a href="/search/blogs/Phil-Hansen"><span style="font-size: 11px !important;">Phil Hansen</span></a>
+ 		<a href="/search/blogs/Paul-Cullen"><span style="font-size: 11px !important;">Paul Cullen</span></a>
+ 		<a href="/search/blogs/Timeline-Skateboards"><span style="font-size: 11px !important;">Timeline Skateboards</span></a>
+ 		<a href="/search/blogs/Cordell-Mansfield"><span style="font-size: 11px !important;">Cordell Mansfield</span></a>
+ 		<a href="/search/blogs/FUEL.TV"><span style="font-size: 11px !important;">FUEL.TV</span></a>
+ 		<a href="/search/blogs/Mark-Appleyard"><span style="font-size: 12px !important;">Mark Appleyard</span></a>
+ 		<a href="/search/blogs/Austin-Ayers"><span style="font-size: 11px !important;">Austin Ayers</span></a>
+ 		<a href="/search/blogs/Dave-Bachinsky"><span style="font-size: 12px !important;">Dave Bachinsky</span></a>
+</p>
+    </div>
+    <!--/.content-->
+</div>
+<!--/.box01 tags-->
+
+
+<div class="ad03"  id="OAS_Middle1">
+
+</div> 
+
+     
+        </div>
+        <!--/.rightPanel-->
+        <div class="clearFloats"></div>
+        <div id="OAS_Bottom" class="ad"></div>        
+    </div>
+    <!--/masterContainer--><!--END INCLUDED CONTENT-->        
+<!--// Test -->
+
+<div class="box01 moreBNQT">
+    <h2><span>More on BNQT</span></h2>
+    <div class="content">
+    <table cellpadding="0" cellspacing="0" border="0" width="100%">
+    <col width="5%" />
+    <col width="90%" />
+    <col width="5%" />
+    	<tr>
+        	<td align="center"><a href="javascript: void(0);" id="ho_next" title="Previous">&#9664;</a></td>
+            <td>
+
+            	<div id="moreOnBNQT" class="horinaja">
+            		<ul>
+						<li>
+							        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://www.bnqt.com/blogs/detail/Badass-Freediver-Holds-Lungs-Breaks-Records/10229" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/editor/0001-42c20dd2-4eb4754c-77b5-2defb986_thumb.jpg" width="165" alt="Badass Freediver Holds Lungs / Breaks Records" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://www.bnqt.com/blogs/detail/Badass-Freediver-Holds-Lungs-Breaks-Records/10229" target="blank">Badass Freediver Holds Lungs / Breaks Records</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    						        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://www.bnqt.com/blogs/detail/Bouldering-Champion-Gets-Grilled-by-Bear-Grylls/10230" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/editor/0001-42c20dd2-4eb47683-cc63-1dbffa70_thumb.jpg" width="165" alt="Bouldering Champion Gets Grilled by Bear Grylls" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://www.bnqt.com/blogs/detail/Bouldering-Champion-Gets-Grilled-by-Bear-Grylls/10230" target="blank">Bouldering Champion Gets Grilled by Bear Grylls</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    						        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://www.bnqt.com/blogs/detail/Rob-Dyrdeks-Girlfriend-is-Smokin/8164" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/editor/0001-42c20dd2-4dc0997d-45b2-f61f94db_thumb.jpg" width="165" alt="Rob Dyrdek\'s Girlfriend is Smokin\'" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://www.bnqt.com/blogs/detail/Rob-Dyrdeks-Girlfriend-is-Smokin/8164" target="blank">Rob Dyrdek's Girlfriend is Smokin'</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    						        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://thedailyrotter.com/blogs/detail/The-Gsport-Ratchet-Hubguard-Steven-Seagal-Tested-And-Reviewed/5090" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/the-daily-rotter/media/alex-bermudez/000b-181e93bf-4b0bc3d8-f6e7-1c900116_thumb.jpg" width="165" alt="The Gsport Ratchet Hubguard: Steven Seagal Tested And Reviewed." />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://thedailyrotter.com/blogs/detail/The-Gsport-Ratchet-Hubguard-Steven-Seagal-Tested-And-Reviewed/5090" target="blank">The Gsport Ratchet Hubguard: Steven Seagal Tested And Reviewed.</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    						        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://www.bnqt.com/blogs/detail/Would-You-Monyca-byrne-Wickey/10179" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/editor/would-you/0001-aefe3553-4eb0133f-87df-178649b5_thumb.jpg" width="165" alt="Would You? - Monyca byrne-Wickey" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://www.bnqt.com/blogs/detail/Would-You-Monyca-byrne-Wickey/10179" target="blank">Would You? - Monyca byrne-Wickey</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    	      					</li>
+								<li>
+							        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://www.bnqt.com/blogs/detail/Veronika-Sznajder-Would-You/10362" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/editor/0001-45360772-4ecbb089-3557-bdce1614_thumb.jpg" width="165" alt="Veronika Sznajder: Would You?" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://www.bnqt.com/blogs/detail/Veronika-Sznajder-Would-You/10362" target="blank">Veronika Sznajder: Would You?</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    						        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://BMXwonderland.com/blogs/detail/Baco-a-Go-Go-comp-in-WISCONSIN/5072" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bmxwonderland.com/media/justin-kosman/0006-181e93bf-4b085504-7eba-f454ec20_thumb.jpg" width="165" alt="Baco-a-Go-Go comp in WISCONSIN" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://BMXwonderland.com/blogs/detail/Baco-a-Go-Go-comp-in-WISCONSIN/5072" target="blank">Baco-a-Go-Go comp in WISCONSIN</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    						        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://www.bnqt.com/blogs/detail/Top-10-Skateboarding-Career-Comebacks/10197" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/jay-r/0001-42c20dd2-4eb20df3-fd1f-8f570200_thumb.jpg" width="165" alt="Top 10 - Skateboarding Career Comebacks" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://www.bnqt.com/blogs/detail/Top-10-Skateboarding-Career-Comebacks/10197" target="blank">Top 10 - Skateboarding Career Comebacks</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    						        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://www.bnqt.com/blogs/detail/Watch-Naive-Internet-Fan-Get-Tased-by-Crazy-Russian/10221" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/editor/0001-42c20dd2-4eb42b92-2de6-2b5e395f_thumb.jpg" width="165" alt="Watch Naive Internet Fan Get Tased by Crazy Russian" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://www.bnqt.com/blogs/detail/Watch-Naive-Internet-Fan-Get-Tased-by-Crazy-Russian/10221" target="blank">Watch Naive Internet Fan Get Tased by Crazy Russian</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    						        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://bmxunion.bnqt.com/videos/detail/The-Union-Dave-Mahoney-at-Vans-Skatepark/1244040692001" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/the-union/media/bmx-union/images/0044-602a55b8-4ea96ae2-c3e0-27580db0_thumb.jpg" width="165" alt="The Union - Dave Mahoney at Vans Skatepark" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://bmxunion.bnqt.com/videos/detail/The-Union-Dave-Mahoney-at-Vans-Skatepark/1244040692001" target="blank">The Union - Dave Mahoney at Vans Skatepark</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    	      					</li>
+								<li>
+							        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://www.bnqt.com/blogs/detail/Watch-Surfer-Ride-Worlds-Biggest-Wave-Ever/10254" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/editor/0001-42c20dd2-4eb97387-0d98-382576a2_thumb.jpg" width="165" alt="Watch Surfer Ride World\'s Biggest Wave - Ever!" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://www.bnqt.com/blogs/detail/Watch-Surfer-Ride-Worlds-Biggest-Wave-Ever/10254" target="blank">Watch Surfer Ride World's Biggest Wave - Ever!</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    						        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://www.bnqt.com/blogs/detail/Top-20-Snowboard-Films-For-2011-2012-Season/10083" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/drew/0001-42c20dd2-4ea09318-1598-42dd7e63_thumb.jpg" width="165" alt="Top 20 Snowboard Films For 2011-2012 Season" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://www.bnqt.com/blogs/detail/Top-20-Snowboard-Films-For-2011-2012-Season/10083" target="blank">Top 20 Snowboard Films For 2011-2012 Season</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    						        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://www.bnqt.com/blogs/detail/Travis-Rice-Premieres-Art-of-Flight/9590" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/editor/art-of-flight/0001-413397c6-4e68dcd9-27fa-4e3d99ee_thumb.jpg" width="165" alt="Travis Rice Premieres Art of Flight" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://www.bnqt.com/blogs/detail/Travis-Rice-Premieres-Art-of-Flight/9590" target="blank">Travis Rice Premieres Art of Flight</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    						        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://www.bnqt.com/blogs/detail/Slater-Wins-11th-World-Title-And-Remembers-Andy-Irons/10195" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/editor/0001-42c20dd2-4eb1d49b-b639-290e1d54_thumb.png" width="165" alt="Slater Wins 11th World Title And Remembers Andy Irons" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://www.bnqt.com/blogs/detail/Slater-Wins-11th-World-Title-And-Remembers-Andy-Irons/10195" target="blank">Slater Wins 11th World Title And Remembers Andy Irons</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    						        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://afroice.com/blogs/detail/Julien-Regnier-joins-Black-Crows/5114" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/afroice/media/iceman/ski/0004-42c20dd2-4b15a965-fe9d-8c8df62d_thumb.png" width="165" alt="Julien Regnier joins Black Crows" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://afroice.com/blogs/detail/Julien-Regnier-joins-Black-Crows/5114" target="blank">Julien Regnier joins Black Crows</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    	      					</li>
+								<li>
+							        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://www.bnqt.com/blogs/detail/REWIND-MIKEY-TAYLOR/10143" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/jay-r/0001-42c20dd2-4eaa14b0-3a2e-5ede8959_thumb.jpg" width="165" alt="REWIND - MIKEY TAYLOR" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://www.bnqt.com/blogs/detail/REWIND-MIKEY-TAYLOR/10143" target="blank">REWIND - MIKEY TAYLOR</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    						        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://www.bnqt.com/blogs/detail/Top-10-Skateboarding-Vanishing-Acts/10266" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/jay-r/0001-42c20dd2-4eb9fdd7-0346-c116988f_thumb.jpg" width="165" alt="Top 10 Skateboarding Vanishing Acts" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://www.bnqt.com/blogs/detail/Top-10-Skateboarding-Vanishing-Acts/10266" target="blank">Top 10 Skateboarding Vanishing Acts</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    						        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://www.bnqt.com/blogs/detail/Alana-Blanchard-Would-You/4226" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/cyrus/0001-42c20dd2-4aa16d4a-b6d8-69838ce5_thumb.jpg" width="165" alt="Alana Blanchard: Would You?" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://www.bnqt.com/blogs/detail/Alana-Blanchard-Would-You/4226" target="blank">Alana Blanchard: Would You?</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    						        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://www.bnqt.com/videos/detail/BNQT-BEST-OF...-SKI-RESORTS-2011-2012/1219159204001" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/editor/0001-42c20dd2-4ea1df65-0b25-60e9c4df_thumb.jpg" width="165" alt="BNQT BEST OF... SKI RESORTS 2011-2012" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://www.bnqt.com/videos/detail/BNQT-BEST-OF...-SKI-RESORTS-2011-2012/1219159204001" target="blank">BNQT BEST OF... SKI RESORTS 2011-2012</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    						        <table cellpadding="0" cellspacing="0" class="dataContent" width="165px">
+					            <tr>
+					                <td height="113">
+										<a href="http://www.bnqt.com/blogs/detail/Nicole-Dabeau-Would-You/10240" target="_blank">
+											<img src="http://img.bnqt.com/CMS/bnqt/network/bnqt.com/media/editor/0001-42c20dd2-4eb8a983-2fc2-d2407046_thumb.jpg" width="165" alt="Nicole Dabeau: Would You?" />
+										</a></td>
+					            </tr>
+					            <tr>
+					                <td class="defaultColor02 padding5" style="word-break: break-all;">
+					                        <p><a href="http://www.bnqt.com/blogs/detail/Nicole-Dabeau-Would-You/10240" target="blank">Nicole Dabeau: Would You?</a></p>
+					                   
+
+					                </td>
+					            </tr>
+					        </table>
+    	      					</li>
+							</ul>
+	            	<div class="clearFloats"></div>
+	            </div>
+            </td>
+            <td align="center"><a href="javascript: void(0);" id="ho_prev" title="Next">&#9654;</a></td>
+        </tr>
+    </table>
+</div>
+<!--/.content-->
+</div>
+<!--/.moreBNQT-->
+<script>
+document.observe("dom:loaded", function() { 
+var Hori = new Horinaja('moreOnBNQT',0.6,10,false);
+});
+</script> 
+
+<div class="clearFloats"></div>
+<div id="masterFooter">
+        <nav id="footer">
+    <dl class="dataList">
+        <dt><strong>content</strong></dt>
+        <dd><a href="http://www.bnqt.com/" title="Home">Home</a></dd>
+        <dd><a href="http://www.bnqt.com/videos/index.html" title="Videos">Videos</a></dd>
+        <dd><a href="http://www.bnqt.com/photos/index.html" title="Photos">Photos</a></dd>
+        <dd><a href="http://www.bnqt.com/blogs/index.html" title="Blogs">Blogs</a></dd>
+    </dl>
+    <!--/.dataList-->
+     <dl class="dataList">
+        <dt><strong>Learn More</strong></dt>
+        <dd><a href="http://bnqtmediagroup.com" target="_blank" title="About BNQT">About BNQT</a></dd>
+        <dd><a href="http://www.bnqt.com/jobs" target="_blank" title="Jobs">Jobs</a></dd>
+        <dd><a href="http://www.bnqt.com/tos" title="Terms &amp; Contitions">Terms &amp; Conditions</a></dd>
+            </dl>
+    <!--/.dataList-->
+    <div class="clearFloats"></div>
+</nav>  
+<!--/nav#footer-->
+<div id="networkBar">
+	<div id="corpInfo" class="floatLeft">
+    	<a href="http://bnqtmediagroup.com/" title="BNQT Media Group" target="_blank" id="logo_bmg"></a>
+        <a href="http://bnqtmediagroup.com/" target="_blank">For Advertisers</a>
+        <a href="http://bnqtmediagroup.com/publishers/" target="_blank">For Publishers</a>
+        <a href="mailto:jasonford&#64;usatoday.com?subject=BNQT%20Media%20Group%20Media%20Kit" target="_blank">Request a Media Kit</a>
+    </div>
+    <!--/corpInfo-->
+    
+        
+        <dl class="floatLeft">
+    	<dt>Lifestyle</dt>
+                <dd><a href="http://hypebeast.com" target="_blank" rel="nofollow">Hypebeast.com</a></dd>
+                <dd><a href="http://flightclub.com" target="_blank" rel="nofollow">Flightclub.com</a></dd>
+                <dd><a href="http://booooooom.com" target="_blank" rel="nofollow">Booooooom.com</a></dd>
+                <dd><a href="http://thecoolist.com" target="_blank" rel="nofollow">TheCoolist.com</a></dd>
+            </dl>
+        <dl class="floatLeft">
+    	<dt>Surf</dt>
+                <dd><a href="http://surfline.com" target="_blank" rel="nofollow">Surfline.com</a></dd>
+                <dd><a href="http://www.surfersvillage.com" target="_blank" rel="nofollow">Surfersvillage.com</a></dd>
+                <dd><a href="http://swellinfo.com" target="_blank" rel="nofollow">SwellInfo.com</a></dd>
+                <dd><a href="http://surfshot.com" target="_blank" rel="nofollow">SurfShot.com</a></dd>
+            </dl>
+        <dl class="floatLeft">
+    	<dt>Skate/Snow</dt>
+                <dd><a href="http://thrashermagazine.com" target="_blank" rel="nofollow">ThrasherMag.com</a></dd>
+                <dd><a href="http://slapmagazine.com" target="_blank" rel="nofollow">SlapMagazine.com</a></dd>
+                <dd><a href="http://tetongravity.com" target="_blank" rel="nofollow">TetonGravity.com</a></dd>
+                <dd><a href="http://yobeat.com" target="_blank" rel="nofollow">YoBeat.com</a></dd>
+            </dl>
+        <dl class="floatLeft">
+    	<dt>Moto/BMX</dt>
+                <dd><a href="http://racerxonline.com" target="_blank" rel="nofollow">RacerXonline.com</a></dd>
+                <dd><a href="http://roadracerx.com" target="_blank" rel="nofollow">RoadRacerX.com</a></dd>
+                <dd><a href="http://thecomeupbmx.net" target="_blank" rel="nofollow">TheComeUpBMX.net</a></dd>
+                <dd><a href="http://defgrip.net" target="_blank" rel="nofollow">DefGrip.net</a></dd>
+            </dl>
+        <dl class="floatLeft">
+    	<dt>Multisport</dt>
+                <dd><a href="http://backcountry.com" target="_blank" rel="nofollow">Backcountry.com</a></dd>
+                <dd><a href="http://freecaster.com" target="_blank" rel="nofollow">Freecaster.com</a></dd>
+                <dd><a href="http://malakye.com" target="_blank" rel="nofollow">Malakye.com</a></dd>
+                <dd><a href="http://bnqt.com" target="_blank" >BNQT.com</a></dd>
+            </dl>
+        <dl class="floatLeft">
+    	<dt>MMA</dt>
+                <dd><a href="http://ufc.com" target="_blank" rel="nofollow">UFC.com</a></dd>
+                <dd><a href="http://mmaconvert.com" target="_blank" rel="nofollow">MMAconvert.com</a></dd>
+                <dd><a href="http://mmajunkie.com" target="_blank" rel="nofollow">MMAJunkie.com</a></dd>
+                <dd><a href="http://middleeasy.com" target="_blank" rel="nofollow">MiddleEasy.com</a></dd>
+            </dl>
+        <dl class="floatLeft">
+    	<dt>Adventure</dt>
+                <dd><a href="http://venturethere.com" target="_blank" >VentureThere.com</a></dd>
+                <dd><a href="http://alpinist.com" target="_blank" rel="nofollow">Alpinist.com</a></dd>
+                <dd><a href="http://trailspace.com" target="_blank" rel="nofollow">TrailSpace.com</a></dd>
+                <dd><a href="http://nsmb.com" target="_blank" rel="nofollow">NSMB.com</a></dd>
+            </dl>
+        
+    <div class="clearFloats"></div>
+    
+    <p id="copy">&copy; 2011 BNQT Media Group / USA Today Sports</p>
+</div>
+<!--/#networkBar-->    </div>
+    <!--/masterFooter-->
+</div>
+<!--/wrapper-->
+<div id="OAS_x01"></div>
+<div id="OAS_x02"></div>
+
+<!--// Google Analytics Start -->
+<script type="text/javascript">
+
+window._gaq = window._gaq || [];
+
+
+_gaq.push(
+    ['domainTracker1._setAccount', "UA-3632331-1"],
+    ['domainTracker1._trackPageview'],
+    ['domainTracker1._trackPageLoadTime']
+);
+
+_gaq.push(
+    ['domainTracker2._setAccount', "UA-3632331-21"],
+    ['domainTracker2._trackPageview'],
+    ['domainTracker2._trackPageLoadTime']
+);
+
+_gaq.push(
+    ['domainTracker3._setAccount', "UA-11570011-6"],
+    ['domainTracker3._trackPageview'],
+    ['domainTracker3._trackPageLoadTime']
+);
+</script>
+<!--// Google Analytics End -->
+
+<script type="text/javascript" src="/js/oas/default.js"></script>
+<!------ OAS MJX Top Ad Calls Begin ------>
+<div id="Hidden_OAS_Top" style="display: none;">
+<script language="javascript" type="text/javascript">
+<!--
+OAS_AD('Top');
+//-->
+</script>
+</div>
+<!------ OAS MJX Middle Ad Calls Begin ------>
+<div id="Hidden_OAS_Middle" style="display: none;">
+<script language="javascript" type="text/javascript">
+<!--
+OAS_AD('Middle');
+//-->
+</script>
+</div>
+<!------ OAS MJX Middle1 Ad Calls Begin ------>
+<div id="Hidden_OAS_Middle1" style="display: none;">
+<script language="javascript" type="text/javascript">
+<!--
+OAS_AD('Middle1');
+//-->
+</script>
+</div>
+<!------ OAS MJX Bottom Ad Calls Begin ------>
+<div id="Hidden_OAS_Bottom" style="display: none;">
+<script language="javascript" type="text/javascript">
+<!--
+OAS_AD('Bottom');
+//-->
+</script>
+</div>
+<!------ OAS MJX x01 Ad Calls Begin ------>
+<div id="Hidden_OAS_x01" style="display: none;">
+<script language="javascript" type="text/javascript">
+<!--
+OAS_AD('x01');
+//-->
+</script>
+</div>
+<!------ OAS MJX x02 Ad Calls Begin ------>
+<div id="Hidden_OAS_x02" style="display: none;">
+<script language="javascript" type="text/javascript">
+<!--
+OAS_AD('x02');
+//-->
+</script>
+</div>
+<!------ OAS MJX Footer Ad Calls End ------>
+<script type="text/javascript">
+/*  Addition of ComSCORE beacon by Joseph Youngquist */
+var __cs_c1 = 2; // Required, and value should be 2
+var __cs_c2 = "6035223"; // Required, ID supplied by comSCORE
+var __cs_params = ["c1=", __cs_c1, "&c2=", __cs_c2].join('');
+document.write(unescape("%3Cscript src='" + (document.location.protocol == "https:" ? "https://sb" : "http://b") +
+".scorecardresearch.com/beacon.js?" + __cs_params +"' %3E%3C/script%3E"));
+/* End comScore */
+</script>
+<script type="text/javascript">
+			(function() {
+				var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+				ga.src = "http://www.google-analytics.com/ga.js";
+				var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+			})();
+
+</script>
+</body>
+</html>

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -461,5 +461,10 @@ class TestParser < Test::Unit::TestCase
    edoc
     assert_equal "7ff5e90iormq5niy6x98j75", doc.at("/html/head/meta[@name='verification']")['content']
  end
+ 
+ def test_nil_attr
+   # parsing this file was failing on JRuby
+   assert_nothing_raised {Hpricot.parse(TestFiles::BNQT)}
+ end
 
 end


### PR DESCRIPTION
Bug in the title (described in Issue #8) was introduced, at least in case of JRuby, after allowing escaping quote characters in attributes (Issue #50 by Masamitsu MURASE).  
Some pages cause such exception. This pull request fixes it, without removing escaped quotes in attributes. 
